### PR TITLE
add install/uninstall script and update README installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,48 +36,130 @@ Two components work together:
 
 ### Prerequisites
 
-- Python 3.10+
+- [Python 3.10+](https://www.python.org/downloads/)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) package manager
 - Ableton Live 12 (any edition)
-- macOS or Windows
+- macOS (Windows support coming soon)
 - [Cursor](https://cursor.com) or [Claude Desktop](https://claude.ai/download)
 
-### 1. Install the MCP server
+### 1. Clone and install dependencies
 
 ```bash
-pip install mcp-ableton
+git clone https://github.com/malmazuke/Ableton-Live-MCP.git
+cd Ableton-Live-MCP
+uv sync
 ```
 
 ### 2. Install the Remote Script
 
-Copy into Ableton's Remote Scripts folder:
+The setup tool automatically finds your Ableton Remote Scripts directory and creates a symlink:
 
 ```bash
-# macOS
-cp -r remote_script/AbletonLiveMCP/ ~/Music/Ableton/User\ Library/Remote\ Scripts/
-
-# Windows
-xcopy remote_script\AbletonLiveMCP "%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonLiveMCP" /E /I
+uv run mcp-ableton-setup
 ```
 
-### 3. Enable in Ableton
+This keeps the Remote Script in sync with the repository -- any updates you pull will be reflected immediately.
 
-Open Preferences → Link, Tempo & MIDI → set a Control Surface slot to **AbletonLiveMCP** (Input/Output: None).
+<details>
+<summary>Setup options</summary>
 
-### 4. Connect your AI assistant
+```bash
+uv run mcp-ableton-setup --dry-run        # preview without making changes
+uv run mcp-ableton-setup --method copy     # copy files instead of symlink
+uv run mcp-ableton-setup --target /path    # override auto-detected directory
+uv run mcp-ableton-setup --uninstall       # remove the Remote Script
+```
 
-Add the server to your MCP config:
+</details>
+
+<details>
+<summary>Manual installation (fallback)</summary>
+
+If the setup tool doesn't work for your system, copy the Remote Script manually:
+
+**macOS:**
+```bash
+cp -r remote_script/AbletonLiveMCP ~/Music/Ableton/User\ Library/Remote\ Scripts/
+```
+
+**Windows:**
+```powershell
+Copy-Item -Recurse remote_script\AbletonLiveMCP "$env:USERPROFILE\Documents\Ableton\User Library\Remote Scripts\"
+```
+
+</details>
+
+### 3. Configure Ableton Live
+
+1. Open (or restart) Ableton Live 12
+2. Go to **Preferences** (Cmd+, on macOS)
+3. Navigate to **Link, Tempo & MIDI**
+4. In an empty **Control Surface** slot, select **AbletonLiveMCP**
+5. Set both **Input** and **Output** to **None**
+
+You should see `AbletonLiveMCP: Listening for commands on port 9877` in the status bar at the bottom of the Ableton window.
+
+### 4. Configure your AI assistant
+
+**Cursor:**
+
+Go to Settings > MCP > Add new MCP server, then enter:
 
 ```json
 {
   "mcpServers": {
     "AbletonLiveMCP": {
-      "command": "mcp-ableton"
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/Ableton-Live-MCP", "mcp-ableton"]
     }
   }
 }
 ```
 
-In **Cursor**, add this under Settings → MCP. For **Claude Desktop**, add it to your Claude config file.
+Replace `/path/to/Ableton-Live-MCP` with the actual path to your cloned repository.
+
+**Claude Desktop:**
+
+Edit your config file (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "AbletonLiveMCP": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/Ableton-Live-MCP", "mcp-ableton"]
+    }
+  }
+}
+```
+
+### 5. Verify
+
+1. Make sure Ableton Live is running with the Remote Script active (check the status bar)
+2. Open a new chat in your AI assistant
+3. Try: *"Get information about my current Ableton session"*
+
+### Uninstalling
+
+Remove the Remote Script from Ableton:
+
+```bash
+uv run mcp-ableton-setup --uninstall
+```
+
+Then remove the MCP server configuration from your AI assistant's settings.
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Remote Script not appearing in Ableton | Restart Ableton after running the setup tool. Check that the symlink/directory exists in your Remote Scripts folder. |
+| "Connection refused" errors | Make sure Ableton Live is running and the AbletonLiveMCP control surface is selected in Preferences. |
+| Port 9877 already in use | Another instance may be running. Close other Ableton instances or applications using that port. |
+| Setup tool can't find Remote Scripts directory | Use `--target /path/to/Remote\ Scripts` to specify the directory manually. |
+| Changes not reflected after git pull | If you installed with `--method copy`, re-run `uv run mcp-ableton-setup` to update. Symlink installs update automatically. |
+
+For more detailed instructions, see [docs/installation.md](docs/installation.md).
 
 ## Current status
 

--- a/Tests/test_setup.py
+++ b/Tests/test_setup.py
@@ -1,0 +1,264 @@
+"""Tests for the Remote Script setup / installer module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from mcp_ableton.setup import (
+    REMOTE_SCRIPT_NAME,
+    _choose_target,
+    detect_remote_scripts_dirs,
+    find_remote_script_source,
+    install,
+    uninstall,
+)
+
+
+@pytest.fixture()
+def source_dir(tmp_path: Path) -> Path:
+    """Create a fake Remote Script source directory."""
+    source = tmp_path / "remote_script" / REMOTE_SCRIPT_NAME
+    source.mkdir(parents=True)
+    (source / "__init__.py").write_text("# stub")
+    (source / "tcp_server.py").write_text("# stub")
+    return source
+
+
+@pytest.fixture()
+def target_dir(tmp_path: Path) -> Path:
+    """Create a fake Ableton Remote Scripts directory."""
+    target = tmp_path / "Remote Scripts"
+    target.mkdir(parents=True)
+    return target
+
+
+class TestFindRemoteScriptSource:
+    def test_finds_source_from_project_root(self) -> None:
+        source = find_remote_script_source()
+        assert source.is_dir()
+        assert source.name == REMOTE_SCRIPT_NAME
+        assert (source / "__init__.py").exists()
+
+    def test_raises_if_source_missing(self, tmp_path: Path) -> None:
+        fake_setup = tmp_path / "src" / "mcp_ableton" / "setup.py"
+        fake_setup.parent.mkdir(parents=True)
+        fake_setup.write_text("")
+
+        with (
+            patch("mcp_ableton.setup.__file__", str(fake_setup)),
+            pytest.raises(FileNotFoundError, match="Remote Script source"),
+        ):
+            find_remote_script_source()
+
+
+class TestDetectRemoteScriptsDirs:
+    def test_returns_existing_dirs_macos(self, tmp_path: Path) -> None:
+        user_library = (
+            tmp_path / "Music" / "Ableton" / "User Library" / "Remote Scripts"
+        )
+        user_library.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            dirs = detect_remote_scripts_dirs()
+
+        assert user_library in dirs
+
+    def test_returns_empty_when_no_dirs_exist(self, tmp_path: Path) -> None:
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            dirs = detect_remote_scripts_dirs()
+
+        assert dirs == []
+
+    def test_finds_user_remote_scripts_macos(self, tmp_path: Path) -> None:
+        prefs = tmp_path / "Library" / "Preferences" / "Ableton" / "Live 12.1"
+        user_remote = prefs / "User Remote Scripts"
+        user_remote.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            dirs = detect_remote_scripts_dirs()
+
+        assert user_remote in dirs
+
+    def test_returns_existing_dirs_windows(self, tmp_path: Path) -> None:
+        user_library = (
+            tmp_path / "Documents" / "Ableton" / "User Library" / "Remote Scripts"
+        )
+        user_library.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Windows"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            dirs = detect_remote_scripts_dirs()
+
+        assert user_library in dirs
+
+    def test_exits_on_unsupported_platform(self) -> None:
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Linux"),
+            pytest.raises(SystemExit),
+        ):
+            detect_remote_scripts_dirs()
+
+
+class TestChooseTarget:
+    def test_auto_selects_user_library_macos(self, tmp_path: Path) -> None:
+        user_library = (
+            tmp_path / "Music" / "Ableton" / "User Library" / "Remote Scripts"
+        )
+        user_library.mkdir(parents=True)
+        per_version = (
+            tmp_path
+            / "Library"
+            / "Preferences"
+            / "Ableton"
+            / "Live 12.2.5"
+            / "User Remote Scripts"
+        )
+        per_version.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            result = _choose_target([user_library, per_version])
+
+        assert result == user_library
+
+    def test_prompts_when_no_user_library(self, tmp_path: Path) -> None:
+        dir_a = tmp_path / "Live 12" / "User Remote Scripts"
+        dir_b = tmp_path / "Live 11" / "User Remote Scripts"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+            patch("builtins.input", return_value="2"),
+        ):
+            result = _choose_target([dir_a, dir_b])
+
+        assert result == dir_b
+
+    def test_returns_single_dir_without_prompting(self, tmp_path: Path) -> None:
+        single = tmp_path / "User Remote Scripts"
+        single.mkdir(parents=True)
+
+        with (
+            patch("mcp_ableton.setup.platform.system", return_value="Darwin"),
+            patch("mcp_ableton.setup.Path.home", return_value=tmp_path),
+        ):
+            result = _choose_target([single])
+
+        assert result == single
+
+
+class TestInstall:
+    def test_install_symlink(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="symlink")
+
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        assert dest.is_symlink()
+        assert dest.resolve() == source_dir.resolve()
+
+    def test_install_copy(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="copy")
+
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        assert dest.is_dir()
+        assert not dest.is_symlink()
+        assert (dest / "__init__.py").exists()
+        assert (dest / "tcp_server.py").exists()
+
+    def test_install_idempotent_symlink(
+        self, target_dir: Path, source_dir: Path
+    ) -> None:
+        install(target_dir, source_dir, method="symlink")
+        install(target_dir, source_dir, method="symlink")
+
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        assert dest.is_symlink()
+        assert dest.resolve() == source_dir.resolve()
+
+    def test_install_replaces_existing_copy_with_symlink(
+        self, target_dir: Path, source_dir: Path
+    ) -> None:
+        install(target_dir, source_dir, method="copy")
+        assert not (target_dir / REMOTE_SCRIPT_NAME).is_symlink()
+
+        install(target_dir, source_dir, method="symlink")
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        assert dest.is_symlink()
+        assert dest.resolve() == source_dir.resolve()
+
+    def test_install_replaces_stale_symlink(
+        self, target_dir: Path, source_dir: Path, tmp_path: Path
+    ) -> None:
+        old_source = tmp_path / "old_source"
+        old_source.mkdir()
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        dest.symlink_to(old_source)
+
+        install(target_dir, source_dir, method="symlink")
+        assert dest.is_symlink()
+        assert dest.resolve() == source_dir.resolve()
+
+    def test_install_dry_run(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="symlink", dry_run=True)
+
+        dest = target_dir / REMOTE_SCRIPT_NAME
+        assert not dest.exists()
+
+    def test_install_creates_target_dir(self, tmp_path: Path, source_dir: Path) -> None:
+        new_target = tmp_path / "new" / "Remote Scripts"
+        install(new_target, source_dir, method="symlink")
+        assert (new_target / REMOTE_SCRIPT_NAME).is_symlink()
+
+
+class TestUninstall:
+    def test_uninstall_symlink(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="symlink")
+
+        with patch("builtins.input", return_value="y"):
+            uninstall(target_dir)
+
+        assert not (target_dir / REMOTE_SCRIPT_NAME).exists()
+
+    def test_uninstall_copy(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="copy")
+
+        with patch("builtins.input", return_value="y"):
+            uninstall(target_dir)
+
+        assert not (target_dir / REMOTE_SCRIPT_NAME).exists()
+
+    def test_uninstall_aborted(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="symlink")
+
+        with patch("builtins.input", return_value="n"):
+            uninstall(target_dir)
+
+        assert (target_dir / REMOTE_SCRIPT_NAME).exists()
+
+    def test_uninstall_nothing_to_remove(self, target_dir: Path) -> None:
+        uninstall(target_dir)
+
+    def test_uninstall_dry_run(self, target_dir: Path, source_dir: Path) -> None:
+        install(target_dir, source_dir, method="symlink")
+        uninstall(target_dir, dry_run=True)
+        assert (target_dir / REMOTE_SCRIPT_NAME).exists()

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,21 +4,13 @@
 
 ## Prerequisites
 
-- Python 3.10+
-- [uv](https://docs.astral.sh/uv/) (recommended) or pip
-- Ableton Live 12 (any edition)
-- macOS or Windows
-- Cursor IDE or Claude Desktop
+- **Python 3.10+** -- [download](https://www.python.org/downloads/) if not already installed
+- **uv** -- install with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). See [uv docs](https://docs.astral.sh/uv/getting-started/installation/).
+- **Ableton Live 12** (any edition -- Intro, Standard, or Suite)
+- **macOS** (Windows support is planned)
+- **Cursor IDE** or **Claude Desktop** (or any MCP-compatible AI client)
 
-## Steps
-
-### 1. Install the MCP Server
-
-```bash
-pip install mcp-ableton
-```
-
-Or for development:
+## Step 1: Clone and install
 
 ```bash
 git clone https://github.com/malmazuke/Ableton-Live-MCP.git
@@ -26,60 +18,211 @@ cd Ableton-Live-MCP
 uv sync
 ```
 
-### 2. Install the Remote Script
+This installs all Python dependencies and registers the CLI entry points (`mcp-ableton` and `mcp-ableton-setup`).
 
-Copy the Remote Script into Ableton's Remote Scripts folder:
+## Step 2: Install the Remote Script
+
+### Automated (recommended)
+
+```bash
+uv run mcp-ableton-setup
+```
+
+The setup tool:
+
+1. Detects your Ableton Remote Scripts directory automatically
+2. Creates a **symlink** from the detected directory to the `remote_script/AbletonLiveMCP/` folder in this repository
+3. Prints next steps for configuring Ableton
+
+Because it uses a symlink, any changes you pull from the repository are reflected immediately -- no need to re-run the setup.
+
+#### Setup options
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would happen without making changes |
+| `--method copy` | Copy files instead of creating a symlink |
+| `--method symlink` | Create a symlink (default) |
+| `--target /path` | Override auto-detection and install to a specific directory |
+| `--uninstall` | Remove a previously installed Remote Script |
+
+#### Where does it install?
+
+The tool searches these locations (in order):
+
+**macOS:**
+
+| Location | Notes |
+|----------|-------|
+| `~/Music/Ableton/User Library/Remote Scripts/` | User Library (recommended, works with Live 10.1.13+) |
+| `~/Library/Preferences/Ableton/Live <version>/User Remote Scripts/` | Per-version user scripts |
+
+**Windows:**
+
+| Location | Notes |
+|----------|-------|
+| `~\Documents\Ableton\User Library\Remote Scripts\` | User Library |
+| `%APPDATA%\Ableton\Live <version>\Preferences\User Remote Scripts\` | Per-version user scripts |
+
+If multiple directories are found, the tool prompts you to choose. If none are found, it tells you the expected path and suggests using `--target`.
+
+### Manual installation (fallback)
+
+If the setup tool doesn't work for your system, create the symlink (or copy the files) yourself.
+
+**macOS (symlink):**
+
+```bash
+ln -s "$(pwd)/remote_script/AbletonLiveMCP" \
+  ~/Music/Ableton/User\ Library/Remote\ Scripts/AbletonLiveMCP
+```
+
+**macOS (copy):**
+
+```bash
+cp -r remote_script/AbletonLiveMCP \
+  ~/Music/Ableton/User\ Library/Remote\ Scripts/
+```
+
+**Windows (copy):**
+
+```powershell
+Copy-Item -Recurse remote_script\AbletonLiveMCP `
+  "$env:USERPROFILE\Documents\Ableton\User Library\Remote Scripts\"
+```
+
+> If the `Remote Scripts` directory doesn't exist yet, create it first.
+
+## Step 3: Configure Ableton Live
+
+1. Open (or restart) Ableton Live 12
+2. Go to **Preferences** (Cmd+, on macOS, Ctrl+, on Windows)
+3. Navigate to the **Link, Tempo & MIDI** tab
+4. Find an empty **Control Surface** slot
+5. Select **AbletonLiveMCP** from the dropdown
+6. Set both **Input** and **Output** to **None**
+
+**How to verify:** look at the status bar at the bottom of the Ableton window. You should see:
+
+```
+AbletonLiveMCP: Listening for commands on port 9877
+```
+
+If you don't see this message, check Ableton's log file (see [Troubleshooting](#troubleshooting) below).
+
+## Step 4: Configure your AI assistant
+
+The MCP server communicates with your AI assistant over stdio. You need to tell the assistant how to start it.
+
+### Cursor IDE
+
+Go to **Settings > MCP > Add new MCP server** and enter:
+
+```json
+{
+  "mcpServers": {
+    "AbletonLiveMCP": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/Ableton-Live-MCP", "mcp-ableton"]
+    }
+  }
+}
+```
+
+Replace `/path/to/Ableton-Live-MCP` with the absolute path to your cloned repository.
+
+### Claude Desktop
+
+Edit the Claude Desktop config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following:
+
+```json
+{
+  "mcpServers": {
+    "AbletonLiveMCP": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/Ableton-Live-MCP", "mcp-ableton"]
+    }
+  }
+}
+```
+
+> Only run one MCP server instance at a time. If you have both Cursor and Claude Desktop configured, only use one at a time.
+
+## Step 5: Verify the connection
+
+1. Make sure Ableton Live is running with the AbletonLiveMCP control surface active
+2. Open a new chat in your AI assistant
+3. Ask: *"Get information about my current Ableton session"*
+
+If everything is working, the assistant will return details about your Live set (tempo, track count, etc.).
+
+## Uninstalling
+
+### Remove the Remote Script
+
+```bash
+uv run mcp-ableton-setup --uninstall
+```
+
+Or manually remove the symlink/directory:
 
 **macOS:**
 ```bash
-cp -r remote_script/AbletonLiveMCP ~/Music/Ableton/User\ Library/Remote\ Scripts/
+rm ~/Music/Ableton/User\ Library/Remote\ Scripts/AbletonLiveMCP
 ```
 
-**Windows:**
+Then restart Ableton Live.
+
+### Remove the MCP server
+
+Remove the `AbletonLiveMCP` entry from your AI assistant's MCP configuration.
+
+## Troubleshooting
+
+### Remote Script doesn't appear in Ableton's Control Surface dropdown
+
+- Restart Ableton after installing the Remote Script.
+- Verify the files are in the right place:
+  ```bash
+  ls ~/Music/Ableton/User\ Library/Remote\ Scripts/AbletonLiveMCP/
+  ```
+  You should see `__init__.py`, `tcp_server.py`, `dispatcher.py`, and `handlers/`.
+- If using a symlink, verify it's not broken: `ls -la ~/Music/Ableton/User\ Library/Remote\ Scripts/AbletonLiveMCP`
+
+### "Connection refused" or timeout errors
+
+- Make sure Ableton Live is running and the AbletonLiveMCP control surface is selected.
+- Check that nothing else is using port 9877: `lsof -i :9877` (macOS).
+- Look at the Ableton log for error messages (see below).
+
+### Port 9877 already in use
+
+Another process is using the port. Close other Ableton instances or find the process:
+
 ```bash
-xcopy remote_script\AbletonLiveMCP "%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonLiveMCP" /E /I
+lsof -i :9877    # macOS
 ```
 
-### 3. Configure Ableton Live
+### Finding Ableton's log file
 
-1. Open Ableton Live 12
-2. Go to Preferences (Cmd + ,)
-3. Navigate to Link, Tempo & MIDI
-4. Set an empty Control Surface slot to **AbletonLiveMCP**
-5. Set Input and Output to **None**
+The log file contains detailed error output from the Remote Script:
 
-You should see "AbletonLiveMCP: Listening for commands on port 9877" in the status bar.
+- **macOS:** `~/Library/Preferences/Ableton/Live <version>/Log.txt`
+- **Windows:** `%APPDATA%\Ableton\Live <version>\Preferences\Log.txt`
 
-### 4. Connect Your AI Assistant
+Search for `AbletonLiveMCP` or `RemoteScriptError` in the log to find relevant entries.
 
-**Cursor IDE:**
+### Changes not reflected after `git pull`
 
-Add to your MCP config (Settings > MCP):
+If you installed with `--method copy`, you need to re-run the setup to copy the updated files:
 
-```json
-{
-  "mcpServers": {
-    "AbletonLiveMCP": {
-      "command": "mcp-ableton"
-    }
-  }
-}
+```bash
+uv run mcp-ableton-setup
 ```
 
-**Claude Desktop:**
-
-Edit your Claude config file:
-
-```json
-{
-  "mcpServers": {
-    "AbletonLiveMCP": {
-      "command": "mcp-ableton"
-    }
-  }
-}
-```
-
-### 5. Verify
-
-Open a new chat and try: "Get information about my current Ableton session"
+If you installed with the default symlink method, changes are picked up automatically -- just restart Ableton.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
 [project.scripts]
 mcp-ableton = "mcp_ableton.server:main"
+mcp-ableton-setup = "mcp_ableton.setup:main"
 
 [dependency-groups]
 dev = [

--- a/src/mcp_ableton/setup.py
+++ b/src/mcp_ableton/setup.py
@@ -1,0 +1,279 @@
+"""Install and uninstall the AbletonLiveMCP Remote Script."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+from pathlib import Path
+
+REMOTE_SCRIPT_NAME = "AbletonLiveMCP"
+
+BOLD = "\033[1m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+RESET = "\033[0m"
+
+
+def _supports_color() -> bool:
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _fmt(text: str, code: str) -> str:
+    if not _supports_color():
+        return text
+    return f"{code}{text}{RESET}"
+
+
+def find_remote_script_source() -> Path:
+    """Locate the ``remote_script/AbletonLiveMCP/`` directory in the project."""
+    project_root = Path(__file__).resolve().parents[2]
+    source = project_root / "remote_script" / REMOTE_SCRIPT_NAME
+    if not source.is_dir():
+        raise FileNotFoundError(
+            f"Remote Script source not found at {source}. "
+            "Are you running from the project repository?"
+        )
+    return source
+
+
+def _macos_user_library() -> Path:
+    return Path.home() / "Music" / "Ableton" / "User Library" / "Remote Scripts"
+
+
+def _macos_candidate_dirs() -> list[Path]:
+    candidates: list[Path] = [_macos_user_library()]
+
+    prefs_dir = Path.home() / "Library" / "Preferences" / "Ableton"
+    if prefs_dir.is_dir():
+        for version_dir in sorted(prefs_dir.iterdir(), reverse=True):
+            user_remote = version_dir / "User Remote Scripts"
+            if user_remote.is_dir():
+                candidates.append(user_remote)
+
+    return candidates
+
+
+def _windows_user_library() -> Path:
+    return Path.home() / "Documents" / "Ableton" / "User Library" / "Remote Scripts"
+
+
+def _windows_candidate_dirs() -> list[Path]:
+    candidates: list[Path] = [_windows_user_library()]
+
+    appdata = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    ableton_prefs = appdata / "Ableton"
+    if ableton_prefs.is_dir():
+        for version_dir in sorted(ableton_prefs.iterdir(), reverse=True):
+            user_remote = version_dir / "Preferences" / "User Remote Scripts"
+            if user_remote.is_dir():
+                candidates.append(user_remote)
+
+    return candidates
+
+
+def _user_library_dir() -> Path:
+    """Return the OS-specific User Library Remote Scripts path."""
+    if platform.system() == "Darwin":
+        return _macos_user_library()
+    return _windows_user_library()
+
+
+def detect_remote_scripts_dirs() -> list[Path]:
+    """Return candidate Remote Scripts directories that exist on this system.
+
+    The User Library directory is always first when present, followed by any
+    per-version ``User Remote Scripts`` directories.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        candidates = _macos_candidate_dirs()
+    elif system == "Windows":
+        candidates = _windows_candidate_dirs()
+    else:
+        print(_fmt(f"Unsupported platform: {system}", RED))
+        print("See docs/installation.md for manual installation instructions.")
+        sys.exit(1)
+
+    return [d for d in candidates if d.is_dir()]
+
+
+def _choose_target(dirs: list[Path]) -> Path:
+    """Pick the best target directory, prompting only when necessary.
+
+    If the User Library directory is among the candidates it is selected
+    automatically (it works across all Ableton versions). The user is only
+    prompted when multiple per-version directories exist and the User Library
+    is not available.
+    """
+    user_library = _user_library_dir()
+    if user_library in dirs:
+        print(f"Using User Library: {user_library}")
+        return user_library
+
+    if len(dirs) == 1:
+        return dirs[0]
+
+    print(f"Found {len(dirs)} Remote Scripts directories:\n")
+    for i, d in enumerate(dirs, 1):
+        print(f"  {i}) {d}")
+    print()
+
+    while True:
+        try:
+            choice = input("Select a directory [1]: ").strip()
+            if not choice:
+                return dirs[0]
+            idx = int(choice) - 1
+            if 0 <= idx < len(dirs):
+                return dirs[idx]
+        except (ValueError, EOFError):
+            pass
+        print(f"Please enter a number between 1 and {len(dirs)}.")
+
+
+def install(
+    target_dir: Path,
+    source: Path,
+    *,
+    method: str = "symlink",
+    dry_run: bool = False,
+) -> None:
+    """Install the Remote Script into *target_dir*."""
+    dest = target_dir / REMOTE_SCRIPT_NAME
+
+    if dest.exists() or dest.is_symlink():
+        if dest.is_symlink():
+            existing_target = dest.resolve()
+            if existing_target == source.resolve():
+                print(
+                    _fmt("Already installed", GREEN)
+                    + f" (symlink at {dest} -> {existing_target})"
+                )
+                return
+            label = f"symlink -> {existing_target}"
+        else:
+            label = "directory"
+        print(f"Removing existing {label} at {dest}")
+        if not dry_run:
+            if dest.is_symlink() or dest.is_file():
+                dest.unlink()
+            else:
+                shutil.rmtree(dest)
+
+    if method == "symlink":
+        print(f"Creating symlink: {dest} -> {source}")
+        if not dry_run:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest.symlink_to(source)
+    else:
+        print(f"Copying files to {dest}")
+        if not dry_run:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source, dest)
+
+    status = "[dry run] " if dry_run else ""
+    print(_fmt(f"\n{status}Remote Script installed successfully!", GREEN))
+    print("\nNext steps:")
+    print("  1. Open (or restart) Ableton Live")
+    print("  2. Go to Preferences > Link, Tempo & MIDI")
+    print(f'  3. Set a Control Surface to "{REMOTE_SCRIPT_NAME}"')
+    print('  4. Set Input and Output to "None"')
+
+
+def uninstall(target_dir: Path, *, dry_run: bool = False) -> None:
+    """Remove the Remote Script from *target_dir*."""
+    dest = target_dir / REMOTE_SCRIPT_NAME
+
+    if not dest.exists() and not dest.is_symlink():
+        print(f"Nothing to uninstall at {dest}")
+        return
+
+    label = f"symlink -> {dest.resolve()}" if dest.is_symlink() else "directory"
+    print(f"Found {label} at {dest}")
+
+    if not dry_run:
+        confirm = input("Remove it? [y/N]: ").strip().lower()
+        if confirm not in ("y", "yes"):
+            print("Aborted.")
+            return
+
+    if not dry_run:
+        if dest.is_symlink() or dest.is_file():
+            dest.unlink()
+        else:
+            shutil.rmtree(dest)
+
+    status = "[dry run] " if dry_run else ""
+    print(_fmt(f"{status}Remote Script uninstalled.", GREEN))
+    print("Restart Ableton Live to complete removal.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="mcp-ableton-setup",
+        description="Install or uninstall the AbletonLiveMCP Remote Script.",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Remove the Remote Script instead of installing it.",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["symlink", "copy"],
+        default="symlink",
+        help='Installation method (default: symlink). Use "copy" if symlinks '
+        "are not supported on your system.",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="Override auto-detection and install into this directory.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes.",
+    )
+    return parser
+
+
+def main() -> None:
+    """CLI entry point for Remote Script setup."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    print(_fmt("AbletonLiveMCP Remote Script Setup\n", BOLD))
+
+    if args.dry_run:
+        print(_fmt("[dry-run mode — no changes will be made]\n", YELLOW))
+
+    source = find_remote_script_source()
+
+    if args.target:
+        target_dir = args.target.expanduser().resolve()
+        if not target_dir.is_dir() and not args.uninstall:
+            print(_fmt(f"Target directory does not exist: {target_dir}", RED))
+            sys.exit(1)
+    else:
+        dirs = detect_remote_scripts_dirs()
+        if not dirs:
+            print(_fmt("No Ableton Remote Scripts directory found.", RED))
+            print()
+            default = _user_library_dir()
+            print(f"Expected location: {default}")
+            print("Create this directory or use --target to specify a path.")
+            sys.exit(1)
+        else:
+            target_dir = _choose_target(dirs)
+
+    if args.uninstall:
+        uninstall(target_dir, dry_run=args.dry_run)
+    else:
+        install(target_dir, source, method=args.method, dry_run=args.dry_run)


### PR DESCRIPTION
## Summary

- Adds `mcp-ableton-setup` CLI tool that automates Remote Script installation into Ableton's Remote Scripts directory via symlink (default) or copy
- Supports `--uninstall`, `--dry-run`, `--method`, and `--target` flags
- Auto-detects the User Library path and selects it without prompting; only prompts when multiple per-version directories exist and no User Library is found
- Rewrites README and `docs/installation.md` with accurate dev-install instructions, setup script usage, verification steps, and troubleshooting

## Changes

- **New:** `src/mcp_ableton/setup.py` -- installer module (stdlib only, no new dependencies)
- **New:** `Tests/test_setup.py` -- 22 tests covering path detection, install, uninstall, idempotency, auto-select, and dry-run
- **Modified:** `pyproject.toml` -- added `mcp-ableton-setup` entry point
- **Modified:** `README.md` -- rewrote Getting Started section with `uv run mcp-ableton-setup`, proper MCP configs, troubleshooting table
- **Modified:** `docs/installation.md` -- full installation guide with manual fallback, OS-specific paths, log file locations

## Test plan

- [x] All 78 tests pass (`uv run pytest`)
- [x] `uv run mcp-ableton-setup --help` works
- [x] `uv run mcp-ableton-setup` auto-detects User Library and creates symlink
- [x] Ruff lint and format checks pass
- [x] Verify symlinked Remote Script loads in Ableton Live

Closes #32