### PR TITLE
Add track management MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — This project is in early development and is not yet functional. The communication infrastructure between the MCP server and Ableton is in place, but no tools are available yet. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport** and **track management** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 

--- a/Tests/test_dispatcher.py
+++ b/Tests/test_dispatcher.py
@@ -9,8 +9,10 @@ import pytest
 from AbletonLiveMCP import create_instance
 from AbletonLiveMCP.dispatcher import (
     INTERNAL_ERROR,
+    NOT_FOUND,
     UNKNOWN_COMMAND,
     Dispatcher,
+    NotFoundError,
 )
 
 
@@ -28,6 +30,13 @@ class _FakeControlSurface:
 
     def schedule_message(self, delay, callback):
         callback()
+
+
+class _NotFoundHandler:
+    """Handler that raises :class:`NotFoundError` for dispatcher mapping tests."""
+
+    def handle_missing(self, params):
+        raise NotFoundError("resource not found")
 
 
 class _SampleHandler:
@@ -89,6 +98,19 @@ class TestCommandRouting:
         assert resp["status"] == "error"
         assert resp["error"]["code"] == INTERNAL_ERROR
         assert "tempo is required" in resp["error"]["message"]
+
+
+class TestNotFoundError:
+    def test_not_found_maps_to_not_found_code(self) -> None:
+        cs = _FakeControlSurface()
+        d = Dispatcher(cs)
+        d.register("nf", _NotFoundHandler())
+
+        resp = d.dispatch("nf.missing", {}, "nf-1")
+
+        assert resp["status"] == "error"
+        assert resp["error"]["code"] == NOT_FOUND
+        assert "resource not found" in resp["error"]["message"]
 
 
 class TestUnknownCommands:

--- a/Tests/test_track_handler.py
+++ b/Tests/test_track_handler.py
@@ -1,0 +1,190 @@
+"""Tests for the Remote Script TrackHandler."""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import MagicMock
+
+import pytest
+from AbletonLiveMCP.dispatcher import Dispatcher, InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.track import TrackHandler
+
+
+class _Mixer:
+    def __init__(self, volume: float = 0.8, pan: float = 0.1) -> None:
+        self.volume = MagicMock(value=volume)
+        self.panning = MagicMock(value=pan)
+
+
+class _Slot:
+    def __init__(self, has_clip: bool = False) -> None:
+        self.has_clip = has_clip
+
+
+class _Device:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _Track:
+    def __init__(
+        self,
+        name: str,
+        *,
+        midi: bool = True,
+        audio: bool = False,
+        can_be_armed: bool = True,
+    ) -> None:
+        self.name = name
+        self.has_audio_input = audio
+        self.has_midi_input = midi
+        self.mute = False
+        self.solo = False
+        self.arm = False
+        self.can_be_armed = can_be_armed
+        self.mixer_device = _Mixer()
+        self.devices = [_Device("Device A")]
+        self.clip_slots = [_Slot(False), _Slot(True)]
+
+
+class _FakeSong:
+    def __init__(self) -> None:
+        self.tracks = [_Track("One"), _Track("Two")]
+
+    def create_midi_track(self, index: int) -> None:
+        t = _Track("New MIDI", midi=True)
+        if index == -1:
+            self.tracks.append(t)
+        else:
+            self.tracks.insert(index, t)
+
+    def create_audio_track(self, index: int) -> None:
+        t = _Track("New Audio", midi=False, audio=True)
+        if index == -1:
+            self.tracks.append(t)
+        else:
+            self.tracks.insert(index, t)
+
+    def delete_track(self, index: int) -> None:
+        del self.tracks[index]
+
+    def duplicate_track(self, index: int) -> None:
+        src = self.tracks[index]
+        dup = copy.copy(src)
+        dup.mixer_device = _Mixer(
+            volume=src.mixer_device.volume.value,
+            pan=src.mixer_device.panning.value,
+        )
+        self.tracks.insert(index + 1, dup)
+
+
+class _FakeControlSurface:
+    def __init__(self, song: _FakeSong | None = None) -> None:
+        self._song = song or _FakeSong()
+
+    def song(self):
+        return self._song
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def show_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay, callback):
+        callback()
+
+
+@pytest.fixture
+def song() -> _FakeSong:
+    return _FakeSong()
+
+
+@pytest.fixture
+def handler(song: _FakeSong) -> TrackHandler:
+    return TrackHandler(_FakeControlSurface(song))
+
+
+class TestGetInfo:
+    def test_returns_expected_shape(self, handler: TrackHandler) -> None:
+        result = handler.handle_get_info({"track_index": 1})
+
+        assert result["name"] == "One"
+        assert result["track_index"] == 1
+        assert result["is_midi_track"] is True
+        assert result["device_names"] == ["Device A"]
+        assert result["clip_slot_has_clip"] == [False, True]
+
+    def test_raises_not_found(self, handler: TrackHandler) -> None:
+        with pytest.raises(NotFoundError, match="Track 99"):
+            handler.handle_get_info({"track_index": 99})
+
+    def test_missing_track_index(self, handler: TrackHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="track_index"):
+            handler.handle_get_info({})
+
+
+class TestCreateMidi:
+    def test_append(self, handler: TrackHandler, song: _FakeSong) -> None:
+        n_before = len(song.tracks)
+        result = handler.handle_create_midi({"index": -1})
+
+        assert result["track_index"] == n_before + 1
+        assert len(song.tracks) == n_before + 1
+
+    def test_insert_at_zero(self, handler: TrackHandler, song: _FakeSong) -> None:
+        handler.handle_create_midi({"index": 0})
+
+        assert song.tracks[0].name == "New MIDI"
+
+    def test_invalid_index(self, handler: TrackHandler, song: _FakeSong) -> None:
+        with pytest.raises(InvalidParamsError, match="index"):
+            handler.handle_create_midi({"index": 50})
+
+
+class TestDeleteDuplicate:
+    def test_delete(self, handler: TrackHandler, song: _FakeSong) -> None:
+        result = handler.handle_delete({"track_index": 2})
+
+        assert result["track_index"] == 2
+        assert len(song.tracks) == 1
+
+    def test_duplicate(self, handler: TrackHandler, song: _FakeSong) -> None:
+        result = handler.handle_duplicate({"track_index": 1})
+
+        assert result == {"source_track_index": 1, "new_track_index": 2}
+        assert len(song.tracks) == 3
+
+
+class TestSetters:
+    def test_set_name(self, handler: TrackHandler, song: _FakeSong) -> None:
+        handler.handle_set_name({"track_index": 1, "name": "Renamed"})
+
+        assert song.tracks[0].name == "Renamed"
+
+    def test_set_mute(self, handler: TrackHandler, song: _FakeSong) -> None:
+        handler.handle_set_mute({"track_index": 1, "mute": True})
+
+        assert song.tracks[0].mute is True
+
+    def test_set_mute_requires_bool(self, handler: TrackHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="mute"):
+            handler.handle_set_mute({"track_index": 1, "mute": "yes"})
+
+    def test_set_arm_unarmable(self, handler: TrackHandler, song: _FakeSong) -> None:
+        song.tracks[0].can_be_armed = False
+
+        with pytest.raises(InvalidParamsError, match="cannot be armed"):
+            handler.handle_set_arm({"track_index": 1, "arm": True})
+
+
+class TestDispatcherNotFoundIntegration:
+    def test_track_get_info_not_found_via_dispatcher(self, song: _FakeSong) -> None:
+        d = Dispatcher(_FakeControlSurface(song))
+        d.register("track", TrackHandler(_FakeControlSurface(song)))
+
+        resp = d.dispatch("track.get_info", {"track_index": 10}, "r1")
+
+        assert resp["status"] == "error"
+        assert resp["error"]["code"] == "NOT_FOUND"
+        assert "10" in resp["error"]["message"]

--- a/Tests/tools/test_track.py
+++ b/Tests/tools/test_track.py
@@ -1,0 +1,289 @@
+"""Tests for track management MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+from pydantic import ValidationError
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.track import (
+    TrackCreatedResult,
+    TrackDeletedResult,
+    TrackDuplicatedResult,
+    TrackInfo,
+    create_audio_track,
+    create_midi_track,
+    delete_track,
+    duplicate_track,
+    get_track_info,
+    set_track_arm,
+    set_track_mute,
+    set_track_name,
+    set_track_solo,
+)
+
+TOOL_NAMES = [
+    "get_track_info",
+    "create_midi_track",
+    "create_audio_track",
+    "delete_track",
+    "duplicate_track",
+    "set_track_name",
+    "set_track_mute",
+    "set_track_solo",
+    "set_track_arm",
+]
+
+
+def _ok_response(result: dict, request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+TRACK_INFO_RESULT = {
+    "name": "Midi 1",
+    "track_index": 1,
+    "is_audio_track": False,
+    "is_midi_track": True,
+    "mute": False,
+    "solo": False,
+    "arm": False,
+    "volume": 0.85,
+    "pan": 0.0,
+    "device_names": ["Instrument Rack"],
+    "clip_slot_has_clip": [False, True],
+}
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_get_track_info_schema(self) -> None:
+        tool = self._get_tool("get_track_info")
+        props = tool.parameters["properties"]
+        assert "track_index" in props
+        assert props["track_index"]["minimum"] == 1
+
+    def test_create_midi_track_index_default(self) -> None:
+        tool = self._get_tool("create_midi_track")
+        props = tool.parameters["properties"]
+        assert props["index"]["default"] == -1
+
+    def test_create_audio_track_index_default(self) -> None:
+        tool = self._get_tool("create_audio_track")
+        props = tool.parameters["properties"]
+        assert props["index"]["default"] == -1
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    @pytest.mark.parametrize("track_index", [0, -1, -5])
+    def test_get_track_info_rejects_non_positive_index(self, track_index: int) -> None:
+        model = self._arg_model("get_track_info")
+        with pytest.raises(ValidationError):
+            model(track_index=track_index)
+
+    def test_get_track_info_accepts_positive_index(self) -> None:
+        model = self._arg_model("get_track_info")
+        args = model(track_index=3)
+        assert args.track_index == 3
+
+    def test_set_track_name_rejects_empty_name(self) -> None:
+        model = self._arg_model("set_track_name")
+        with pytest.raises(ValidationError):
+            model(track_index=1, name="")
+
+
+class TestGetTrackInfo:
+    async def test_returns_track_info(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_INFO_RESULT)
+
+        result = await get_track_info(ctx=mock_context, track_index=1)
+
+        assert isinstance(result, TrackInfo)
+        assert result.name == "Midi 1"
+        assert result.track_index == 1
+        assert result.is_midi_track is True
+        assert result.clip_slot_has_clip == [False, True]
+
+    async def test_sends_correct_command(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_INFO_RESULT)
+
+        await get_track_info(ctx=mock_context, track_index=2)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.get_info"
+        assert req.params == {"track_index": 2}
+
+    async def test_raises_on_error(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND", message="Track 9 does not exist"
+        )
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_track_info(ctx=mock_context, track_index=9)
+
+
+class TestCreateMidiTrack:
+    async def test_default_index_and_no_name(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 2, "name": None}
+        )
+
+        result = await create_midi_track(ctx=mock_context)
+
+        assert isinstance(result, TrackCreatedResult)
+        assert result.track_index == 2
+        assert result.name is None
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.create_midi"
+        assert req.params == {"index": -1}
+
+    async def test_with_name(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 1, "name": "Bass"}
+        )
+
+        await create_midi_track(
+            ctx=mock_context,
+            index=0,
+            name="Bass",
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.params == {"index": 0, "name": "Bass"}
+
+
+class TestCreateAudioTrack:
+    async def test_sends_create_audio(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 3, "name": None}
+        )
+
+        await create_audio_track(ctx=mock_context, index=-1)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.create_audio"
+        assert req.params == {"index": -1}
+
+
+class TestDeleteDuplicateSetters:
+    async def test_delete_track(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"track_index": 2})
+
+        result = await delete_track(ctx=mock_context, track_index=2)
+
+        assert isinstance(result, TrackDeletedResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.delete"
+        assert req.params == {"track_index": 2}
+
+    async def test_duplicate_track(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"source_track_index": 1, "new_track_index": 2}
+        )
+
+        result = await duplicate_track(ctx=mock_context, track_index=1)
+
+        assert isinstance(result, TrackDuplicatedResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.duplicate"
+
+    async def test_set_track_name(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"track_index": 1})
+
+        await set_track_name(ctx=mock_context, track_index=1, name="Lead")
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.set_name"
+        assert req.params == {"track_index": 1, "name": "Lead"}
+
+    async def test_set_track_mute(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"track_index": 1})
+
+        await set_track_mute(ctx=mock_context, track_index=1, mute=True)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.set_mute"
+        assert req.params == {"track_index": 1, "mute": True}
+
+    async def test_set_track_solo(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"track_index": 2})
+
+        await set_track_solo(ctx=mock_context, track_index=2, solo=False)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.set_solo"
+
+    async def test_set_track_arm(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"track_index": 1})
+
+        await set_track_arm(ctx=mock_context, track_index=1, arm=True)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "track.set_arm"
+        assert req.params == {"track_index": 1, "arm": True}
+
+
+class TestResponseModels:
+    def test_track_info_rejects_missing_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            TrackInfo.model_validate({"name": "x"})
+
+    def test_track_info_accepts_valid(self) -> None:
+        t = TrackInfo.model_validate(TRACK_INFO_RESULT)
+        assert t.device_names == ["Instrument Rack"]

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -484,6 +484,13 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `start_playback` | `session.start_playback` |
 | `get_track_info` | `track.get_info` |
 | `create_midi_track` | `track.create_midi` |
+| `create_audio_track` | `track.create_audio` |
+| `delete_track` | `track.delete` |
+| `duplicate_track` | `track.duplicate` |
+| `set_track_name` | `track.set_name` |
+| `set_track_mute` | `track.set_mute` |
+| `set_track_solo` | `track.set_solo` |
+| `set_track_arm` | `track.set_arm` |
 | `create_clip` | `clip.create` |
 | `add_notes_to_clip` | `clip.add_notes` |
 | `get_clip_notes` | `clip.get_notes` |

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -51,8 +51,10 @@ class AbletonLiveMCP(ControlSurface):
     def _register_handlers(self) -> None:
         """Register command handlers with the dispatcher."""
         from .handlers.session import SessionHandler
+        from .handlers.track import TrackHandler
 
         self._dispatcher.register("session", SessionHandler(self))
+        self._dispatcher.register("track", TrackHandler(self))
 
     def disconnect(self) -> None:
         """Ableton lifecycle hook -- shut down the TCP server."""

--- a/remote_script/AbletonLiveMCP/dispatcher.py
+++ b/remote_script/AbletonLiveMCP/dispatcher.py
@@ -11,10 +11,15 @@ from typing import Any
 UNKNOWN_COMMAND = "UNKNOWN_COMMAND"
 INVALID_PARAMS = "INVALID_PARAMS"
 INTERNAL_ERROR = "INTERNAL_ERROR"
+NOT_FOUND = "NOT_FOUND"
 
 
 class InvalidParamsError(Exception):
     """Raised by handlers when parameters fail semantic validation."""
+
+
+class NotFoundError(Exception):
+    """Raised when a requested resource (e.g. track index) does not exist."""
 
 
 class Dispatcher:
@@ -77,6 +82,8 @@ class Dispatcher:
             return _ok(result, request_id)
         except InvalidParamsError as exc:
             return _error(INVALID_PARAMS, str(exc), request_id)
+        except NotFoundError as exc:
+            return _error(NOT_FOUND, str(exc), request_id)
         except Exception as exc:
             return _error(INTERNAL_ERROR, str(exc), request_id)
 

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -5,5 +5,6 @@ issues as the tool surface grows.
 """
 
 from .session import SessionHandler
+from .track import TrackHandler
 
-__all__ = ["SessionHandler"]
+__all__ = ["SessionHandler", "TrackHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/track.py
+++ b/remote_script/AbletonLiveMCP/handlers/track.py
@@ -1,0 +1,182 @@
+"""Track command handlers for the Ableton Live MCP Remote Script.
+
+Handles ``track.*`` commands. ``track_index`` in params is **1-based**;
+Live's ``song.tracks`` and ``create_*_track`` insert indices use **0-based**
+LOM semantics (``-1`` = append).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class TrackHandler(BaseHandler):
+    """Handle track CRUD and property commands."""
+
+    def _resolve_track(self, params: dict[str, Any]) -> tuple[Any, int, int]:
+        """Return ``(track, track_index_1based, lo_index)`` or raise."""
+        raw = params.get("track_index")
+        if raw is None:
+            raise InvalidParamsError("'track_index' parameter is required")
+        if not isinstance(raw, int):
+            raise InvalidParamsError("'track_index' must be an integer")
+        if raw < 1:
+            raise InvalidParamsError("'track_index' must be at least 1")
+
+        song = self._song
+        tracks = song.tracks
+        n = len(tracks)
+        if raw > n:
+            raise NotFoundError(f"Track {raw} does not exist (song has {n} track(s))")
+        lo = raw - 1
+        return tracks[lo], raw, lo
+
+    def handle_get_info(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return a structured snapshot of one track (read-only)."""
+        track, track_index, _lo = self._resolve_track(params)
+
+        device_names = [d.name for d in track.devices]
+        clip_slot_has_clip = [bool(slot.has_clip) for slot in track.clip_slots]
+
+        return {
+            "name": track.name,
+            "track_index": track_index,
+            "is_audio_track": bool(track.has_audio_input),
+            "is_midi_track": bool(track.has_midi_input),
+            "mute": bool(track.mute),
+            "solo": bool(track.solo),
+            "arm": bool(track.arm),
+            "volume": float(track.mixer_device.volume.value),
+            "pan": float(track.mixer_device.panning.value),
+            "device_names": device_names,
+            "clip_slot_has_clip": clip_slot_has_clip,
+        }
+
+    def handle_create_midi(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Create a MIDI track; optional ``name`` applied on the main thread."""
+        return self._create_track(params, midi=True)
+
+    def handle_create_audio(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Create an audio track; optional ``name`` applied on the main thread."""
+        return self._create_track(params, midi=False)
+
+    def _create_track(self, params: dict[str, Any], *, midi: bool) -> dict[str, Any]:
+        index = params.get("index", -1)
+        if not isinstance(index, int):
+            raise InvalidParamsError("'index' must be an integer")
+        name = params.get("name")
+        if name is not None:
+            if not isinstance(name, str):
+                raise InvalidParamsError("'name' must be a string")
+            if not name.strip():
+                raise InvalidParamsError("'name' must not be empty")
+
+        song = self._song
+
+        def _do_create() -> dict[str, Any]:
+            track_count = len(song.tracks)
+            if index < -1 or (index != -1 and (index < 0 or index > track_count - 1)):
+                raise InvalidParamsError(
+                    f"'index' must be -1 (append) or 0..{track_count - 1}, got {index}"
+                )
+            if midi:
+                song.create_midi_track(index)
+            else:
+                song.create_audio_track(index)
+            new_count = len(song.tracks)
+            lo_new = new_count - 1 if index == -1 else index
+            new_track = song.tracks[lo_new]
+            if name is not None:
+                new_track.name = name
+            return {
+                "track_index": lo_new + 1,
+                "name": new_track.name if name is not None else None,
+            }
+
+        return self._run_on_main_thread(_do_create)
+
+    def handle_delete(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Delete a track by 1-based index."""
+        _track, track_index, lo = self._resolve_track(params)
+
+        def _do_delete() -> dict[str, Any]:
+            self._song.delete_track(lo)
+            return {"track_index": track_index}
+
+        return self._run_on_main_thread(_do_delete)
+
+    def handle_duplicate(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Duplicate a track; copy is inserted immediately after the source."""
+        _track, track_index, lo = self._resolve_track(params)
+
+        def _do_duplicate() -> dict[str, Any]:
+            self._song.duplicate_track(lo)
+            new_lo = lo + 1
+            return {
+                "source_track_index": track_index,
+                "new_track_index": new_lo + 1,
+            }
+
+        return self._run_on_main_thread(_do_duplicate)
+
+    def handle_set_name(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Rename a track."""
+        _track, track_index, lo = self._resolve_track(params)
+        name = params.get("name")
+        if name is None or not isinstance(name, str) or not name.strip():
+            raise InvalidParamsError("'name' must be a non-empty string")
+
+        def _set() -> dict[str, Any]:
+            self._song.tracks[lo].name = name
+            return {"track_index": track_index}
+
+        return self._run_on_main_thread(_set)
+
+    def handle_set_mute(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set track mute."""
+        _track, track_index, lo = self._resolve_track(params)
+        mute = params.get("mute")
+        if mute is None or not isinstance(mute, bool):
+            raise InvalidParamsError("'mute' must be a boolean")
+
+        def _set() -> dict[str, Any]:
+            self._song.tracks[lo].mute = mute
+            return {"track_index": track_index}
+
+        return self._run_on_main_thread(_set)
+
+    def handle_set_solo(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set track solo."""
+        _track, track_index, lo = self._resolve_track(params)
+        solo = params.get("solo")
+        if solo is None or not isinstance(solo, bool):
+            raise InvalidParamsError("'solo' must be a boolean")
+
+        def _set() -> dict[str, Any]:
+            self._song.tracks[lo].solo = solo
+            return {"track_index": track_index}
+
+        return self._run_on_main_thread(_set)
+
+    def handle_set_arm(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Arm or disarm a track for recording."""
+        track, track_index, lo = self._resolve_track(params)
+        arm = params.get("arm")
+        if arm is None or not isinstance(arm, bool):
+            raise InvalidParamsError("'arm' must be a boolean")
+        if not bool(track.can_be_armed):
+            raise InvalidParamsError(
+                f"Track {track_index} cannot be armed (e.g. return/master)"
+            )
+
+        def _set() -> dict[str, Any]:
+            self._song.tracks[lo].arm = arm
+            return {"track_index": track_index}
+
+        return self._run_on_main_thread(_set)
+
+
+__all__ = ["TrackHandler"]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tool modules for the Ableton MCP server."""
 
 import mcp_ableton.tools.session  # noqa: F401
+import mcp_ableton.tools.track  # noqa: F401
 
 __all__: list[str] = []

--- a/src/mcp_ableton/tools/track.py
+++ b/src/mcp_ableton/tools/track.py
@@ -1,0 +1,308 @@
+"""MCP tools for track management in Ableton Live."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+class TrackInfo(BaseModel):
+    """Per-track snapshot returned by ``get_track_info``."""
+
+    name: str
+    track_index: int
+    is_audio_track: bool
+    is_midi_track: bool
+    mute: bool
+    solo: bool
+    arm: bool
+    volume: float
+    pan: float
+    device_names: list[str]
+    clip_slot_has_clip: list[bool]
+
+
+class TrackCreatedResult(BaseModel):
+    """Result of ``create_midi_track`` or ``create_audio_track``."""
+
+    track_index: int
+    name: str | None = None
+
+
+class TrackDeletedResult(BaseModel):
+    """Result of ``delete_track``."""
+
+    track_index: int
+
+
+class TrackDuplicatedResult(BaseModel):
+    """Result of ``duplicate_track``."""
+
+    source_track_index: int
+    new_track_index: int
+
+
+class TrackUpdatedResult(BaseModel):
+    """Result of ``set_track_name``, ``set_track_mute``, etc."""
+
+    track_index: int
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def get_track_info(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(
+            description="1-based index into the song's track list (first track is 1).",
+            ge=1,
+        ),
+    ],
+) -> TrackInfo:
+    """Get information about a track (name, type, mixer, devices, clip slots).
+
+    ``track_index`` is 1-based (the first track is 1). For deep device or clip
+    data, use the dedicated device and clip tools (composition over this view).
+    """
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.get_info",
+        params={"track_index": track_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackInfo.model_validate(response.result)
+
+
+@mcp.tool()
+async def create_midi_track(
+    ctx: Context,
+    index: Annotated[
+        int,
+        Field(
+            description=(
+                "Insert position using Live's API: -1 appends at the end; "
+                "0..N-1 inserts before that 0-based slot (not the same as 1-based "
+                "track_index)."
+            ),
+        ),
+    ] = -1,
+    name: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional track name applied after creation (non-empty if set)."
+            ),
+        ),
+    ] = None,
+) -> TrackCreatedResult:
+    """Create a new MIDI track.
+
+    The ``index`` parameter follows Live's ``create_midi_track`` semantics
+    (0-based insert index, or -1 for end), not 1-based ``track_index``.
+    """
+    connection = _get_connection(ctx)
+    params: dict = {"index": index}
+    if name is not None:
+        params["name"] = name
+    request = CommandRequest(command="track.create_midi", params=params)
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackCreatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def create_audio_track(
+    ctx: Context,
+    index: Annotated[
+        int,
+        Field(
+            description=(
+                "Insert position using Live's API: -1 appends at the end; "
+                "0..N-1 inserts before that 0-based slot."
+            ),
+        ),
+    ] = -1,
+    name: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional track name applied after creation (non-empty if set)."
+            ),
+        ),
+    ] = None,
+) -> TrackCreatedResult:
+    """Create a new audio track.
+
+    The ``index`` parameter follows Live's ``create_audio_track`` semantics
+    (0-based insert index, or -1 for end), not 1-based ``track_index``.
+    """
+    connection = _get_connection(ctx)
+    params: dict = {"index": index}
+    if name is not None:
+        params["name"] = name
+    request = CommandRequest(command="track.create_audio", params=params)
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackCreatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def delete_track(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(
+            description="1-based index of the track to remove.",
+            ge=1,
+        ),
+    ],
+) -> TrackDeletedResult:
+    """Delete a track from the song."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.delete",
+        params={"track_index": track_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackDeletedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def duplicate_track(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(
+            description="1-based index of the track to duplicate.",
+            ge=1,
+        ),
+    ],
+) -> TrackDuplicatedResult:
+    """Duplicate a track; the copy is inserted after the source track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.duplicate",
+        params={"track_index": track_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackDuplicatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_track_name(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    name: Annotated[
+        str,
+        Field(description="New track name.", min_length=1),
+    ],
+) -> TrackUpdatedResult:
+    """Rename a track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.set_name",
+        params={"track_index": track_index, "name": name},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackUpdatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_track_mute(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    mute: Annotated[bool, Field(description="Whether the track is muted.")],
+) -> TrackUpdatedResult:
+    """Set a track's mute state."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.set_mute",
+        params={"track_index": track_index, "mute": mute},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackUpdatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_track_solo(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    solo: Annotated[bool, Field(description="Whether the track is soloed.")],
+) -> TrackUpdatedResult:
+    """Set a track's solo state."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.set_solo",
+        params={"track_index": track_index, "solo": solo},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackUpdatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_track_arm(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    arm: Annotated[
+        bool,
+        Field(description="Whether the track is armed for recording."),
+    ],
+) -> TrackUpdatedResult:
+    """Arm or disarm a track for recording (only if the track can be armed)."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="track.set_arm",
+        params={"track_index": track_index, "arm": arm},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackUpdatedResult.model_validate(response.result)
+
+
+__all__ = [
+    "TrackCreatedResult",
+    "TrackDeletedResult",
+    "TrackDuplicatedResult",
+    "TrackInfo",
+    "TrackUpdatedResult",
+    "create_audio_track",
+    "create_midi_track",
+    "delete_track",
+    "duplicate_track",
+    "get_track_info",
+    "set_track_arm",
+    "set_track_mute",
+    "set_track_name",
+    "set_track_solo",
+]


### PR DESCRIPTION
## Summary

Implements the nine Phase 1 track tools from ADR-002 and issue **#9**: MCP layer (`tools/track.py`), `track.*` Remote Script handlers, `NotFoundError` → `NOT_FOUND` in the dispatcher, and tests mirroring the session tool patterns.

## MCP tools

- `get_track_info`, `create_midi_track`, `create_audio_track`, `delete_track`, `duplicate_track`, `set_track_name`, `set_track_mute`, `set_track_solo`, `set_track_arm`
- **1-based** `track_index` at the MCP boundary; **LOM** `index` (-1 append, 0..n-1 insert before) for create.

## Remote Script

- `TrackHandler` registered on `track`; reads vs main-thread writes consistent with `SessionHandler`.

## Tests

- `Tests/tools/test_track.py`, `Tests/test_track_handler.py`, dispatcher `NOT_FOUND` coverage.

## Manual verification (Live)

Completed in Ableton Live with the Remote Script on port 9877: session/track info, CRUD, mute/solo/arm, duplicate, delete last, out-of-range `NOT_FOUND`, `create_midi_track` with `index: 0`. Session tools regression spot-checked.

## Docs

- ADR-002 Part 4 command table extended with full `track.*` mapping.
- README status line updated (session + track tools shipped).

Closes #9