### PR TITLE
add session clip tools and stabilize live set switching

### DIFF
--- a/Tests/test_clip_handler.py
+++ b/Tests/test_clip_handler.py
@@ -1,0 +1,179 @@
+"""Tests for the Remote Script ClipHandler."""
+
+from __future__ import annotations
+
+import pytest
+from AbletonLiveMCP.dispatcher import InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.clip import ClipHandler
+
+from Tests.test_track_handler import _FakeControlSurface, _FakeSong, _Track
+
+
+class _Clip:
+    def __init__(
+        self,
+        name: str = "Clip",
+        length: float = 4.0,
+        *,
+        audio: bool = False,
+    ) -> None:
+        self.name = name
+        self.length = length
+        self.is_audio_clip = audio
+        self.is_midi_clip = not audio
+        self.is_playing = False
+        self.is_recording = False
+
+
+class _Slot:
+    def __init__(self, clip: _Clip | None = None) -> None:
+        self._clip = clip
+        self.has_clip = clip is not None
+
+    @property
+    def clip(self) -> _Clip:
+        return self._clip
+
+    def create_clip(self, length: float) -> None:
+        if self.has_clip:
+            raise RuntimeError("already has clip")
+        self._clip = _Clip(name="MIDI Clip", length=length, audio=False)
+        self.has_clip = True
+
+    def delete_clip(self) -> None:
+        self._clip = None
+        self.has_clip = False
+
+    def fire(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+def _track_with_slots(*slots: _Slot) -> _Track:
+    t = _Track("Midi", midi=True)
+    t.clip_slots = list(slots)
+    return t
+
+
+class _SongWithClipTracks(_FakeSong):
+    def __init__(self) -> None:
+        self.tracks = [
+            _track_with_slots(_Slot(), _Slot(_Clip("Hi", 2.0)), _Slot()),
+        ]
+
+
+class _TrackDup(_Track):
+    def duplicate_clip_slot(self, index: int) -> None:
+        src_slot = self.clip_slots[index]
+        if not src_slot.has_clip:
+            raise RuntimeError("no clip")
+        for i in range(index + 1, len(self.clip_slots)):
+            if not self.clip_slots[i].has_clip:
+                c = src_slot.clip
+                self.clip_slots[i]._clip = _Clip(
+                    name=c.name + " 2",
+                    length=c.length,
+                    audio=c.is_audio_clip,
+                )
+                self.clip_slots[i].has_clip = True
+                return
+        raise RuntimeError("no empty slot")
+
+
+@pytest.fixture
+def song_clip() -> _SongWithClipTracks:
+    return _SongWithClipTracks()
+
+
+@pytest.fixture
+def handler_clip(song_clip: _SongWithClipTracks) -> ClipHandler:
+    return ClipHandler(_FakeControlSurface(song_clip))
+
+
+class TestCreateDelete:
+    def test_create_empty_slot(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        result = handler_clip.handle_create(
+            {"track_index": 1, "clip_slot_index": 1, "length": 8.0},
+        )
+        assert result == {
+            "track_index": 1,
+            "clip_slot_index": 1,
+            "length": 8.0,
+        }
+        slot = song_clip.tracks[0].clip_slots[0]
+        assert slot.has_clip
+        assert slot.clip.length == 8.0
+
+    def test_create_rejects_audio_track(self) -> None:
+        song = _FakeSong()
+        song.tracks = [_Track("A", midi=False, audio=True)]
+        song.tracks[0].clip_slots = [_Slot()]
+        h = ClipHandler(_FakeControlSurface(song))
+        with pytest.raises(InvalidParamsError, match="MIDI"):
+            h.handle_create({"track_index": 1, "clip_slot_index": 1})
+
+    def test_delete(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        result = handler_clip.handle_delete({"track_index": 1, "clip_slot_index": 2})
+        assert result == {"track_index": 1, "clip_slot_index": 2}
+        assert not song_clip.tracks[0].clip_slots[1].has_clip
+
+
+class TestDuplicate:
+    def test_duplicate_finds_new_slot(self) -> None:
+        song = _FakeSong()
+        song.tracks = [
+            _TrackDup(
+                "T",
+                midi=True,
+            ),
+        ]
+        song.tracks[0].clip_slots = [
+            _Slot(_Clip("a", 1.0)),
+            _Slot(),
+            _Slot(),
+        ]
+        h = ClipHandler(_FakeControlSurface(song))
+        result = h.handle_duplicate({"track_index": 1, "clip_slot_index": 1})
+        assert result["new_clip_slot_index"] == 2
+        assert song.tracks[0].clip_slots[1].has_clip
+
+
+class TestSetNameFireStopGetInfo:
+    def test_set_name(self, handler_clip: ClipHandler) -> None:
+        r = handler_clip.handle_set_name(
+            {"track_index": 1, "clip_slot_index": 2, "name": "Renamed"},
+        )
+        assert r == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "name": "Renamed",
+        }
+
+    def test_fire_stop(self, handler_clip: ClipHandler) -> None:
+        assert handler_clip.handle_fire(
+            {"track_index": 1, "clip_slot_index": 2},
+        ) == {"track_index": 1, "clip_slot_index": 2}
+        assert handler_clip.handle_stop(
+            {"track_index": 1, "clip_slot_index": 2},
+        ) == {"track_index": 1, "clip_slot_index": 2}
+
+    def test_get_info(self, handler_clip: ClipHandler) -> None:
+        r = handler_clip.handle_get_info({"track_index": 1, "clip_slot_index": 2})
+        assert r["name"] == "Hi"
+        assert r["length"] == 2.0
+        assert r["is_midi_clip"] is True
+        assert r["is_audio_clip"] is False
+
+    def test_get_info_empty_raises(self, handler_clip: ClipHandler) -> None:
+        with pytest.raises(NotFoundError, match="No clip"):
+            handler_clip.handle_get_info({"track_index": 1, "clip_slot_index": 1})

--- a/Tests/tools/test_clip.py
+++ b/Tests/tools/test_clip.py
@@ -1,0 +1,263 @@
+"""Tests for session clip MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+from pydantic import ValidationError
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.clip import (
+    ClipCreatedResult,
+    ClipDuplicatedResult,
+    ClipInfo,
+    ClipRenamedResult,
+    ClipSlotResult,
+    create_clip,
+    delete_clip,
+    duplicate_clip,
+    fire_clip,
+    get_clip_info,
+    set_clip_name,
+    stop_clip,
+)
+
+TOOL_NAMES = [
+    "create_clip",
+    "delete_clip",
+    "duplicate_clip",
+    "set_clip_name",
+    "fire_clip",
+    "stop_clip",
+    "get_clip_info",
+]
+
+
+def _ok_response(result: dict, request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+CLIP_INFO_RESULT = {
+    "track_index": 1,
+    "clip_slot_index": 2,
+    "name": "Kick",
+    "length": 4.0,
+    "is_audio_clip": False,
+    "is_midi_clip": True,
+    "is_playing": True,
+    "is_recording": False,
+}
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_create_clip_schema(self) -> None:
+        tool = self._get_tool("create_clip")
+        props = tool.parameters["properties"]
+        assert props["length"]["default"] == 4.0
+        assert props["clip_slot_index"]["minimum"] == 1
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    @pytest.mark.parametrize("clip_slot_index", [0, -1])
+    def test_create_clip_rejects_bad_slot(
+        self,
+        clip_slot_index: int,
+    ) -> None:
+        model = self._arg_model("create_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_slot_index=clip_slot_index)
+
+    def test_create_clip_rejects_non_positive_length(self) -> None:
+        model = self._arg_model("create_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_slot_index=1, length=0.0)
+
+
+class TestCreateClip:
+    async def test_sends_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 1, "clip_slot_index": 2, "length": 8.0},
+        )
+
+        result = await create_clip(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            length=8.0,
+        )
+
+        assert isinstance(result, ClipCreatedResult)
+        assert result.length == 8.0
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.create"
+        assert req.params == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "length": 8.0,
+        }
+
+
+class TestGetClipInfo:
+    async def test_returns_clip_info(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(CLIP_INFO_RESULT)
+
+        result = await get_clip_info(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+        )
+
+        assert isinstance(result, ClipInfo)
+        assert result.name == "Kick"
+        assert result.is_playing is True
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="No clip in slot",
+        )
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_clip_info(ctx=mock_context, track_index=1, clip_slot_index=1)
+
+
+class TestDeleteDuplicateFireStop:
+    async def test_delete_clip(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 1, "clip_slot_index": 3},
+        )
+
+        result = await delete_clip(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=3,
+        )
+
+        assert isinstance(result, ClipSlotResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.delete"
+
+    async def test_duplicate_clip(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "track_index": 1,
+                "source_clip_slot_index": 1,
+                "new_clip_slot_index": 2,
+            },
+        )
+
+        result = await duplicate_clip(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=1,
+        )
+
+        assert isinstance(result, ClipDuplicatedResult)
+        assert result.new_clip_slot_index == 2
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.duplicate"
+
+    async def test_set_clip_name(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "name": "Snare",
+            },
+        )
+
+        result = await set_clip_name(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            name="Snare",
+        )
+
+        assert isinstance(result, ClipRenamedResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.set_name"
+
+    async def test_fire_and_stop(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 1, "clip_slot_index": 1},
+        )
+
+        await fire_clip(ctx=mock_context, track_index=1, clip_slot_index=1)
+        assert mock_connection.send_command.call_args[0][0].command == "clip.fire"
+
+        mock_connection.send_command.return_value = _ok_response(
+            {"track_index": 1, "clip_slot_index": 1},
+        )
+        await stop_clip(ctx=mock_context, track_index=1, clip_slot_index=1)
+        assert mock_connection.send_command.call_args[0][0].command == "clip.stop"
+
+
+class TestResponseModels:
+    def test_clip_info_rejects_missing_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ClipInfo.model_validate({"track_index": 1})
+
+    def test_clip_info_accepts_valid(self) -> None:
+        c = ClipInfo.model_validate(CLIP_INFO_RESULT)
+        assert c.name == "Kick"

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -50,11 +50,13 @@ class AbletonLiveMCP(ControlSurface):
 
     def _register_handlers(self) -> None:
         """Register command handlers with the dispatcher."""
+        from .handlers.clip import ClipHandler
         from .handlers.session import SessionHandler
         from .handlers.track import TrackHandler
 
         self._dispatcher.register("session", SessionHandler(self))
         self._dispatcher.register("track", TrackHandler(self))
+        self._dispatcher.register("clip", ClipHandler(self))
 
     def disconnect(self) -> None:
         """Ableton lifecycle hook -- shut down the TCP server."""

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -4,7 +4,8 @@ Handler modules (session, track, clip, etc.) will be added by subsequent
 issues as the tool surface grows.
 """
 
+from .clip import ClipHandler
 from .session import SessionHandler
 from .track import TrackHandler
 
-__all__ = ["SessionHandler", "TrackHandler"]
+__all__ = ["ClipHandler", "SessionHandler", "TrackHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/clip.py
+++ b/remote_script/AbletonLiveMCP/handlers/clip.py
@@ -1,0 +1,214 @@
+"""Clip command handlers for session-view clip slots (per track).
+
+``track_index`` and ``clip_slot_index`` are **1-based**, matching other tools.
+LOM uses 0-based indices on ``song.tracks`` and ``track.clip_slots``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class ClipHandler(BaseHandler):
+    """Handle session clip slot commands."""
+
+    def _resolve_track(self, params: dict[str, Any]) -> tuple[Any, int, int]:
+        """Return ``(track, track_index_1based, lo_track)`` or raise."""
+        raw = params.get("track_index")
+        if raw is None:
+            raise InvalidParamsError("'track_index' parameter is required")
+        if not isinstance(raw, int):
+            raise InvalidParamsError("'track_index' must be an integer")
+        if raw < 1:
+            raise InvalidParamsError("'track_index' must be at least 1")
+
+        song = self._song
+        tracks = song.tracks
+        n = len(tracks)
+        if raw > n:
+            raise NotFoundError(f"Track {raw} does not exist (song has {n} track(s))")
+        lo = raw - 1
+        return tracks[lo], raw, lo
+
+    def _resolve_clip_slot(
+        self,
+        params: dict[str, Any],
+    ) -> tuple[Any, Any, int, int, int]:
+        """Return ``(track, clip_slot, track_index_1, clip_slot_index_1, lo_slot)``."""
+        track, track_index, _lo_track = self._resolve_track(params)
+        raw_slot = params.get("clip_slot_index")
+        if raw_slot is None:
+            raise InvalidParamsError("'clip_slot_index' parameter is required")
+        if not isinstance(raw_slot, int):
+            raise InvalidParamsError("'clip_slot_index' must be an integer")
+        if raw_slot < 1:
+            raise InvalidParamsError("'clip_slot_index' must be at least 1")
+
+        slots = track.clip_slots
+        ns = len(slots)
+        if raw_slot > ns:
+            raise NotFoundError(
+                f"Clip slot {raw_slot} does not exist "
+                f"(track {track_index} has {ns} slot(s))"
+            )
+        lo = raw_slot - 1
+        return track, slots[lo], track_index, raw_slot, lo
+
+    def handle_create(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Create an empty MIDI clip in an empty slot (``length`` in beats)."""
+        length = params.get("length", 4.0)
+        if isinstance(length, bool) or not isinstance(length, (int, float)):
+            raise InvalidParamsError("'length' must be a number")
+        if float(length) <= 0:
+            raise InvalidParamsError("'length' must be positive")
+
+        def _do() -> dict[str, Any]:
+            track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            if slot.has_clip:
+                raise InvalidParamsError(
+                    f"Clip slot {slot_index} on track {track_index} already has a clip"
+                )
+            if not bool(track.has_midi_input):
+                raise InvalidParamsError(
+                    "create_clip only applies to MIDI tracks (session MIDI slots)"
+                )
+            slot.create_clip(float(length))
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "length": float(length),
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_delete(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Remove the clip in the given slot."""
+
+        def _do() -> dict[str, Any]:
+            _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            if not slot.has_clip:
+                raise InvalidParamsError(
+                    f"No clip in slot {slot_index} on track {track_index}"
+                )
+            slot.delete_clip()
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_duplicate(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Duplicate the clip in this slot (same semantics as Live's slot duplicate)."""
+
+        def _do() -> dict[str, Any]:
+            track, _slot, track_index, slot_index, lo = self._resolve_clip_slot(
+                params,
+            )
+            if not track.clip_slots[lo].has_clip:
+                raise InvalidParamsError(
+                    f"No clip in slot {slot_index} on track {track_index}"
+                )
+            before = [bool(s.has_clip) for s in track.clip_slots]
+            track.duplicate_clip_slot(lo)
+            after = [bool(s.has_clip) for s in track.clip_slots]
+            new_1based: int | None = None
+            for i in range(len(after)):
+                if after[i] and not before[i]:
+                    new_1based = i + 1
+                    break
+            return {
+                "track_index": track_index,
+                "source_clip_slot_index": slot_index,
+                "new_clip_slot_index": new_1based,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_set_name(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Rename the clip in the given slot."""
+        name = params.get("name")
+        if name is None or not isinstance(name, str) or not name.strip():
+            raise InvalidParamsError("'name' must be a non-empty string")
+
+        def _do() -> dict[str, Any]:
+            _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            if not slot.has_clip:
+                raise InvalidParamsError(
+                    f"No clip in slot {slot_index} on track {track_index}"
+                )
+            slot.clip.name = name
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "name": name,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_fire(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Launch the clip or trigger the slot's stop / record behavior."""
+
+        def _do() -> dict[str, Any]:
+            _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            slot.fire()
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_stop(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Stop playback or recording for this track's slot column."""
+
+        def _do() -> dict[str, Any]:
+            _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            slot.stop()
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_get_info(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return metadata for the clip in the given slot."""
+
+        def _do() -> dict[str, Any]:
+            _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            if not slot.has_clip:
+                raise NotFoundError(
+                    f"No clip in slot {slot_index} on track {track_index}"
+                )
+            clip = slot.clip
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "name": clip.name,
+                "length": float(clip.length),
+                "is_audio_clip": bool(clip.is_audio_clip),
+                "is_midi_clip": bool(clip.is_midi_clip),
+                "is_playing": bool(clip.is_playing),
+                "is_recording": bool(clip.is_recording),
+            }
+
+        return self._run_on_main_thread(_do)
+
+
+__all__ = ["ClipHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/session.py
+++ b/remote_script/AbletonLiveMCP/handlers/session.py
@@ -15,28 +15,28 @@ VALID_DENOMINATORS = frozenset({1, 2, 4, 8, 16, 32})
 class SessionHandler(BaseHandler):
     """Handle session and transport commands.
 
-    Read-only handlers (``handle_get_info``, ``handle_get_playback_position``)
-    run on the client-socket thread.  Write handlers schedule work on
-    Ableton's main thread via ``_run_on_main_thread``.
-
-    Thread-safety note: reading multiple LOM properties from the client
-    thread could theoretically produce inconsistent snapshots if the main
-    thread mutates state mid-read.  Acceptable for Phase 1; wrap in
-    ``_run_on_main_thread`` if manual testing reveals issues.
+    All Live Object Model access runs on Ableton's main thread via
+    ``_run_on_main_thread``.  Calling ``control_surface.song()`` or touching
+    ``song.*`` from the TCP worker thread is unsafe and can crash or error
+    (especially around project load).
     """
 
     def handle_get_info(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return current session state."""
-        song = self._song
-        return {
-            "tempo": song.tempo,
-            "signature_numerator": song.signature_numerator,
-            "signature_denominator": song.signature_denominator,
-            "track_count": len(song.tracks),
-            "is_playing": song.is_playing,
-            "is_recording": song.record_mode,
-            "song_length": song.song_length,
-        }
+
+        def _read() -> dict[str, Any]:
+            song = self._song
+            return {
+                "tempo": song.tempo,
+                "signature_numerator": song.signature_numerator,
+                "signature_denominator": song.signature_denominator,
+                "track_count": len(song.tracks),
+                "is_playing": song.is_playing,
+                "is_recording": song.record_mode,
+                "song_length": song.song_length,
+            }
+
+        return self._run_on_main_thread(_read)
 
     def handle_set_tempo(self, params: dict[str, Any]) -> dict[str, Any]:
         """Set the song tempo in BPM (20--999)."""
@@ -106,22 +106,26 @@ class SessionHandler(BaseHandler):
 
     def handle_get_playback_position(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return current playback position with derived bar/beat values."""
-        song = self._song
-        current_time = song.current_song_time
-        tempo = song.tempo
-        numerator = song.signature_numerator
 
-        bar = int(current_time // numerator) + 1
-        beat_in_bar = (current_time % numerator) + 1
-        time_seconds = current_time * 60.0 / tempo
+        def _read() -> dict[str, Any]:
+            song = self._song
+            current_time = song.current_song_time
+            tempo = song.tempo
+            numerator = song.signature_numerator
 
-        return {
-            "beats": current_time,
-            "bar": bar,
-            "beat_in_bar": beat_in_bar,
-            "time_seconds": time_seconds,
-            "is_playing": song.is_playing,
-        }
+            bar = int(current_time // numerator) + 1
+            beat_in_bar = (current_time % numerator) + 1
+            time_seconds = current_time * 60.0 / tempo
+
+            return {
+                "beats": current_time,
+                "bar": bar,
+                "beat_in_bar": beat_in_bar,
+                "time_seconds": time_seconds,
+                "is_playing": song.is_playing,
+            }
+
+        return self._run_on_main_thread(_read)
 
 
 __all__ = ["SessionHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/track.py
+++ b/remote_script/AbletonLiveMCP/handlers/track.py
@@ -36,24 +36,28 @@ class TrackHandler(BaseHandler):
 
     def handle_get_info(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return a structured snapshot of one track (read-only)."""
-        track, track_index, _lo = self._resolve_track(params)
 
-        device_names = [d.name for d in track.devices]
-        clip_slot_has_clip = [bool(slot.has_clip) for slot in track.clip_slots]
+        def _read() -> dict[str, Any]:
+            track, track_index, _lo = self._resolve_track(params)
 
-        return {
-            "name": track.name,
-            "track_index": track_index,
-            "is_audio_track": bool(track.has_audio_input),
-            "is_midi_track": bool(track.has_midi_input),
-            "mute": bool(track.mute),
-            "solo": bool(track.solo),
-            "arm": bool(track.arm),
-            "volume": float(track.mixer_device.volume.value),
-            "pan": float(track.mixer_device.panning.value),
-            "device_names": device_names,
-            "clip_slot_has_clip": clip_slot_has_clip,
-        }
+            device_names = [d.name for d in track.devices]
+            clip_slot_has_clip = [bool(slot.has_clip) for slot in track.clip_slots]
+
+            return {
+                "name": track.name,
+                "track_index": track_index,
+                "is_audio_track": bool(track.has_audio_input),
+                "is_midi_track": bool(track.has_midi_input),
+                "mute": bool(track.mute),
+                "solo": bool(track.solo),
+                "arm": bool(track.arm),
+                "volume": float(track.mixer_device.volume.value),
+                "pan": float(track.mixer_device.panning.value),
+                "device_names": device_names,
+                "clip_slot_has_clip": clip_slot_has_clip,
+            }
+
+        return self._run_on_main_thread(_read)
 
     def handle_create_midi(self, params: dict[str, Any]) -> dict[str, Any]:
         """Create a MIDI track; optional ``name`` applied on the main thread."""
@@ -74,9 +78,8 @@ class TrackHandler(BaseHandler):
             if not name.strip():
                 raise InvalidParamsError("'name' must not be empty")
 
-        song = self._song
-
         def _do_create() -> dict[str, Any]:
+            song = self._song
             track_count = len(song.tracks)
             if index < -1 or (index != -1 and (index < 0 or index > track_count - 1)):
                 raise InvalidParamsError(
@@ -100,9 +103,9 @@ class TrackHandler(BaseHandler):
 
     def handle_delete(self, params: dict[str, Any]) -> dict[str, Any]:
         """Delete a track by 1-based index."""
-        _track, track_index, lo = self._resolve_track(params)
 
         def _do_delete() -> dict[str, Any]:
+            _track, track_index, lo = self._resolve_track(params)
             self._song.delete_track(lo)
             return {"track_index": track_index}
 
@@ -110,9 +113,9 @@ class TrackHandler(BaseHandler):
 
     def handle_duplicate(self, params: dict[str, Any]) -> dict[str, Any]:
         """Duplicate a track; copy is inserted immediately after the source."""
-        _track, track_index, lo = self._resolve_track(params)
 
         def _do_duplicate() -> dict[str, Any]:
+            _track, track_index, lo = self._resolve_track(params)
             self._song.duplicate_track(lo)
             new_lo = lo + 1
             return {
@@ -124,12 +127,12 @@ class TrackHandler(BaseHandler):
 
     def handle_set_name(self, params: dict[str, Any]) -> dict[str, Any]:
         """Rename a track."""
-        _track, track_index, lo = self._resolve_track(params)
         name = params.get("name")
         if name is None or not isinstance(name, str) or not name.strip():
             raise InvalidParamsError("'name' must be a non-empty string")
 
         def _set() -> dict[str, Any]:
+            _track, track_index, lo = self._resolve_track(params)
             self._song.tracks[lo].name = name
             return {"track_index": track_index}
 
@@ -137,12 +140,12 @@ class TrackHandler(BaseHandler):
 
     def handle_set_mute(self, params: dict[str, Any]) -> dict[str, Any]:
         """Set track mute."""
-        _track, track_index, lo = self._resolve_track(params)
         mute = params.get("mute")
         if mute is None or not isinstance(mute, bool):
             raise InvalidParamsError("'mute' must be a boolean")
 
         def _set() -> dict[str, Any]:
+            _track, track_index, lo = self._resolve_track(params)
             self._song.tracks[lo].mute = mute
             return {"track_index": track_index}
 
@@ -150,12 +153,12 @@ class TrackHandler(BaseHandler):
 
     def handle_set_solo(self, params: dict[str, Any]) -> dict[str, Any]:
         """Set track solo."""
-        _track, track_index, lo = self._resolve_track(params)
         solo = params.get("solo")
         if solo is None or not isinstance(solo, bool):
             raise InvalidParamsError("'solo' must be a boolean")
 
         def _set() -> dict[str, Any]:
+            _track, track_index, lo = self._resolve_track(params)
             self._song.tracks[lo].solo = solo
             return {"track_index": track_index}
 
@@ -163,16 +166,16 @@ class TrackHandler(BaseHandler):
 
     def handle_set_arm(self, params: dict[str, Any]) -> dict[str, Any]:
         """Arm or disarm a track for recording."""
-        track, track_index, lo = self._resolve_track(params)
         arm = params.get("arm")
         if arm is None or not isinstance(arm, bool):
             raise InvalidParamsError("'arm' must be a boolean")
-        if not bool(track.can_be_armed):
-            raise InvalidParamsError(
-                f"Track {track_index} cannot be armed (e.g. return/master)"
-            )
 
         def _set() -> dict[str, Any]:
+            track, track_index, lo = self._resolve_track(params)
+            if not bool(track.can_be_armed):
+                raise InvalidParamsError(
+                    f"Track {track_index} cannot be armed (e.g. return/master)"
+                )
             self._song.tracks[lo].arm = arm
             return {"track_index": track_index}
 

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tool modules for the Ableton MCP server."""
 
+import mcp_ableton.tools.clip  # noqa: F401
 import mcp_ableton.tools.session  # noqa: F401
 import mcp_ableton.tools.track  # noqa: F401
 

--- a/src/mcp_ableton/tools/clip.py
+++ b/src/mcp_ableton/tools/clip.py
@@ -1,0 +1,246 @@
+"""MCP tools for session-view clips in Ableton Live."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+class ClipCreatedResult(BaseModel):
+    """Result of ``create_clip``."""
+
+    track_index: int
+    clip_slot_index: int
+    length: float
+
+
+class ClipSlotResult(BaseModel):
+    """Result of ``delete_clip``, ``fire_clip``, or ``stop_clip``."""
+
+    track_index: int
+    clip_slot_index: int
+
+
+class ClipDuplicatedResult(BaseModel):
+    """Result of ``duplicate_clip``."""
+
+    track_index: int
+    source_clip_slot_index: int
+    new_clip_slot_index: int | None = None
+
+
+class ClipRenamedResult(BaseModel):
+    """Result of ``set_clip_name``."""
+
+    track_index: int
+    clip_slot_index: int
+    name: str
+
+
+class ClipInfo(BaseModel):
+    """Session clip metadata from ``get_clip_info``."""
+
+    track_index: int
+    clip_slot_index: int
+    name: str
+    length: float
+    is_audio_clip: bool
+    is_midi_clip: bool
+    is_playing: bool
+    is_recording: bool
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+ClipSlotIndex = Annotated[
+    int,
+    Field(
+        description=(
+            "1-based scene/slot index on the track (first row in Session View is 1)."
+        ),
+        ge=1,
+    ),
+]
+
+
+@mcp.tool()
+async def create_clip(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based index of the track.", ge=1),
+    ],
+    clip_slot_index: ClipSlotIndex,
+    length: Annotated[
+        float,
+        Field(
+            description="Clip length in beats (positive).",
+            gt=0,
+        ),
+    ] = 4.0,
+) -> ClipCreatedResult:
+    """Create an empty MIDI clip in a session slot.
+
+    The slot must be empty and the track must accept MIDI clips (MIDI track).
+    """
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.create",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "length": length,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipCreatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def delete_clip(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+) -> ClipSlotResult:
+    """Delete the clip in a session slot."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.delete",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipSlotResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def duplicate_clip(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+) -> ClipDuplicatedResult:
+    """Duplicate a session clip (same behavior as Live's clip-slot duplicate)."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.duplicate",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipDuplicatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_clip_name(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    name: Annotated[str, Field(description="New clip name.", min_length=1)],
+) -> ClipRenamedResult:
+    """Rename the clip in a session slot."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.set_name",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "name": name,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipRenamedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def fire_clip(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+) -> ClipSlotResult:
+    """Start or trigger the session slot (launch clip, record, or stop button)."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.fire",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipSlotResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def stop_clip(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+) -> ClipSlotResult:
+    """Stop playback or recording for this slot column on the track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.stop",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipSlotResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_clip_info(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+) -> ClipInfo:
+    """Get metadata for the clip in a session slot."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.get_info",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipInfo.model_validate(response.result)
+
+
+__all__ = [
+    "ClipCreatedResult",
+    "ClipDuplicatedResult",
+    "ClipInfo",
+    "ClipRenamedResult",
+    "ClipSlotResult",
+    "create_clip",
+    "delete_clip",
+    "duplicate_clip",
+    "fire_clip",
+    "get_clip_info",
+    "set_clip_name",
+    "stop_clip",
+]


### PR DESCRIPTION
## Summary
- add session clip MCP tools (`create_clip`, `delete_clip`, `duplicate_clip`, `set_clip_name`, `fire_clip`, `stop_clip`, `get_clip_info`) and wire them into tool registration
- add Remote Script `clip` handler category and register it in the dispatcher/control surface lifecycle
- fix Live Object Model thread-safety by running session/track/clip reads and track resolution on Ableton's main thread, preventing failures when switching to a new Live Set without restarting Ableton
- add handler and tool tests for clip operations

## Test plan
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] manual MCP smoke tests in Ableton Live: `create_clip`, `set_clip_name`, `get_clip_info`, `fire_clip`, `stop_clip`, `duplicate_clip`, `delete_clip`
- [x] manual regression check: open a new Live Set without restarting Ableton, then call `get_session_info` successfully

Closes #11 