### PR TITLE
Document tempo automation limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ The communication layer between the MCP server and Ableton's Remote Script is bu
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 
+## Known limitations
+
+- `set_tempo` style commands can change the current song tempo at runtime.
+- Native Arrangement tempo automation on the Main track is **not** currently supported.
+- On Ableton Live 12.2.5, Live exposes `song.tempo` for direct tempo changes, but does not expose a supported public runtime API for creating or editing the Main track's tempo automation envelope.
+- Because of that limitation, Ableton Live MCP does **not** attempt to patch `.als` files, drive the Live UI, or require extra OS permissions just to emulate tempo automation. If Ableton exposes a supported API for this in a future Live release, the feature can be revisited.
+
 **Planned capabilities:**
 
 | Area | Examples |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -161,6 +161,13 @@ Add the following:
 
 If everything is working, the assistant will return details about your Live set (tempo, track count, etc.).
 
+## Known runtime limitations
+
+- Live tempo changes are supported through the public runtime API.
+- Native Arrangement tempo automation on the Main track is not currently supported.
+- In Ableton Live 12.2.5, the public Live Object Model exposes `song.tempo` for immediate tempo changes, but it does not expose a supported public runtime API for writing the Main track's tempo automation envelope.
+- Ableton Live MCP intentionally avoids workarounds that would require patching `.als` files, driving the UI, or requesting additional OS permissions. The goal is for the server to work through supported runtime APIs only.
+
 ## Uninstalling
 
 ### Remove the Remote Script


### PR DESCRIPTION
## Summary
- document that runtime tempo changes are supported but native Arrangement tempo automation is not
- record the Ableton Live 12.2.5 limitation in the README and installation guide
- make it explicit that the project will not rely on .als patching, UI automation, or extra OS permissions for this feature

## Context
Related to #41.

Investigation on March 27, 2026 confirmed:
- `set_tempo` works end to end through the MCP server path in Ableton Live 12.2.5
- the public runtime API does not expose a supported way to create or edit the Main track tempo automation envelope

## Verification
- documentation-only change
- tests not run