### PR TITLE
Add browser MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport** and **track management** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport**, **track management**, **session clip**, **MIDI note**, and **browser** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 

--- a/Tests/test_browser_handler.py
+++ b/Tests/test_browser_handler.py
@@ -1,0 +1,177 @@
+"""Tests for the Remote Script BrowserHandler."""
+
+from __future__ import annotations
+
+import pytest
+from AbletonLiveMCP.dispatcher import InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.browser import BrowserHandler
+
+
+class _BrowserItem:
+    def __init__(
+        self,
+        name: str,
+        *,
+        uri: str | None = None,
+        is_loadable: bool = False,
+        children: list[_BrowserItem] | None = None,
+    ) -> None:
+        self.name = name
+        self.uri = uri
+        self.is_loadable = is_loadable
+        self.children = children or []
+        self.is_folder = bool(self.children)
+
+
+class _Browser:
+    def __init__(self) -> None:
+        self.instruments = _BrowserItem(
+            "Instruments",
+            uri="browser:instruments",
+            children=[
+                _BrowserItem(
+                    "Synths",
+                    uri="browser:instruments/synths",
+                    children=[
+                        _BrowserItem(
+                            "Analog",
+                            uri="browser:instruments/synths/analog",
+                            is_loadable=True,
+                        ),
+                        _BrowserItem(
+                            "Deep Folder",
+                            uri="browser:instruments/synths/deep-folder",
+                            children=[
+                                _BrowserItem(
+                                    "Hidden Child",
+                                    uri=(
+                                        "browser:instruments/synths/"
+                                        "deep-folder/hidden-child"
+                                    ),
+                                    is_loadable=True,
+                                )
+                            ],
+                        ),
+                    ],
+                ),
+                _BrowserItem(
+                    "Keys",
+                    uri="browser:instruments/keys",
+                    children=[],
+                ),
+            ],
+        )
+        self.sounds = _BrowserItem("Sounds", uri="browser:sounds", children=[])
+        self.drums = _BrowserItem("Drums", uri="browser:drums", children=[])
+        self.audio_effects = _BrowserItem(
+            "Audio Effects",
+            uri="browser:audio-effects",
+            children=[],
+        )
+        self.midi_effects = _BrowserItem(
+            "MIDI Effects",
+            uri="browser:midi-effects",
+            children=[],
+        )
+
+
+class _Application:
+    def __init__(self) -> None:
+        self.browser = _Browser()
+
+
+class _FakeControlSurface:
+    def __init__(self) -> None:
+        self._application = _Application()
+
+    def application(self):
+        return self._application
+
+    def song(self):
+        return None
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay, callback) -> None:
+        callback()
+
+
+@pytest.fixture
+def handler() -> BrowserHandler:
+    return BrowserHandler(_FakeControlSurface())
+
+
+class TestGetTree:
+    def test_supported_category_lookup(self, handler: BrowserHandler) -> None:
+        result = handler.handle_get_tree({"category": "instruments"})
+
+        assert len(result["categories"]) == 1
+        assert result["categories"][0]["name"] == "Instruments"
+
+    def test_tree_depth_is_limited(self, handler: BrowserHandler) -> None:
+        result = handler.handle_get_tree({"category": "instruments"})
+
+        deep_folder = result["categories"][0]["children"][0]["children"][1]
+        assert deep_folder["name"] == "Deep Folder"
+        assert deep_folder["children"] == []
+
+    def test_invalid_category_raises(self, handler: BrowserHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="category"):
+            handler.handle_get_tree({"category": "plugins"})
+
+
+class TestGetItems:
+    def test_nested_path_traversal_is_case_insensitive(
+        self,
+        handler: BrowserHandler,
+    ) -> None:
+        result = handler.handle_get_items({"path": "Instruments/sYnThS"})
+
+        assert result["path"] == "instruments/Synths"
+        assert [item["name"] for item in result["items"]] == ["Analog", "Deep Folder"]
+
+    def test_valid_leaf_returns_empty_items(self, handler: BrowserHandler) -> None:
+        result = handler.handle_get_items({"path": "instruments/keys"})
+
+        assert result == {"path": "instruments/Keys", "items": []}
+
+    def test_invalid_path_raises_not_found(self, handler: BrowserHandler) -> None:
+        with pytest.raises(NotFoundError, match="Browser path not found"):
+            handler.handle_get_items({"path": "instruments/missing"})
+
+    def test_blank_path_is_invalid(self, handler: BrowserHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="path"):
+            handler.handle_get_items({"path": "   "})
+
+
+class TestSearch:
+    def test_search_matches_nested_items(self, handler: BrowserHandler) -> None:
+        result = handler.handle_search({"query": "analog", "category": "instruments"})
+
+        assert result["query"] == "analog"
+        assert result["category"] == "instruments"
+        assert result["items"] == [
+            {
+                "name": "Analog",
+                "path": "instruments/Synths/Analog",
+                "uri": "browser:instruments/synths/analog",
+                "is_loadable": True,
+            }
+        ]
+
+    def test_search_misses_return_empty_list(self, handler: BrowserHandler) -> None:
+        result = handler.handle_search({"query": "zzz", "category": "all"})
+
+        assert result["items"] == []
+
+    def test_search_includes_nested_hidden_child(self, handler: BrowserHandler) -> None:
+        result = handler.handle_search({"query": "hidden", "category": "instruments"})
+
+        assert result["items"][0]["path"] == (
+            "instruments/Synths/Deep Folder/Hidden Child"
+        )
+
+    def test_blank_query_is_invalid(self, handler: BrowserHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="query"):
+            handler.handle_search({"query": "   "})

--- a/Tests/test_connection.py
+++ b/Tests/test_connection.py
@@ -6,7 +6,7 @@ import asyncio
 
 import pytest
 
-from mcp_ableton.connection import AbletonConnection
+from mcp_ableton.connection import STREAM_LIMIT, AbletonConnection
 from mcp_ableton.protocol import CommandRequest
 
 
@@ -28,6 +28,35 @@ class TestConnectionDefaults:
         assert conn.host == "192.168.1.10"
         assert conn.port == 1234
         assert conn.timeout == 5.0
+
+    async def test_open_connection_uses_large_stream_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, int] = {}
+
+        class _FakeWriter:
+            def is_closing(self) -> bool:
+                return False
+
+            def close(self) -> None:
+                pass
+
+            async def wait_closed(self) -> None:
+                return None
+
+        async def fake_open_connection(host: str, port: int, *, limit: int):
+            captured["limit"] = limit
+            return asyncio.StreamReader(), _FakeWriter()
+
+        monkeypatch.setattr(asyncio, "open_connection", fake_open_connection)
+
+        conn = AbletonConnection(host="127.0.0.1", port=9877, max_retries=1)
+        await conn.connect()
+
+        assert captured["limit"] == STREAM_LIMIT
+
+        await conn.disconnect()
 
 
 class TestSendCommandRequiresConnection:

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -27,12 +27,44 @@ class _EchoHandler:
         return {"tempo": 120.0, "is_playing": False}
 
 
+class _BrowserHandler:
+    def handle_get_tree(self, params):
+        return {
+            "categories": [
+                {
+                    "name": "Instruments",
+                    "uri": "browser:instruments",
+                    "is_folder": True,
+                    "is_loadable": False,
+                    "children": [
+                        {
+                            "name": "Synths",
+                            "uri": "browser:instruments/synths",
+                            "is_folder": True,
+                            "is_loadable": False,
+                            "children": [
+                                {
+                                    "name": "Analog",
+                                    "uri": "browser:instruments/synths/analog",
+                                    "is_folder": False,
+                                    "is_loadable": True,
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
     cs = _FakeControlSurface()
     dispatcher = Dispatcher(cs)
     dispatcher.register("session", _EchoHandler())
+    dispatcher.register("browser", _BrowserHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -100,5 +132,22 @@ class TestFullRoundTrip:
             resp = await conn.send_command(req)
             assert resp.status == "ok"
             assert resp.id == f"multi-{i}"
+
+        await conn.disconnect()
+
+    async def test_nested_browser_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="browser.get_tree", id="browser-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "browser-1"
+        assert resp.result is not None
+        category = resp.result["categories"][0]
+        assert category["name"] == "Instruments"
+        assert category["children"][0]["children"][0]["name"] == "Analog"
 
         await conn.disconnect()

--- a/Tests/tools/test_browser.py
+++ b/Tests/tools/test_browser.py
@@ -1,0 +1,268 @@
+"""Tests for Browser MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.browser import (
+    BrowserItemsResult,
+    BrowserSearchResult,
+    BrowserTree,
+    get_browser_items,
+    get_browser_tree,
+    search_browser,
+)
+
+TOOL_NAMES = [
+    "get_browser_tree",
+    "get_browser_items",
+    "search_browser",
+]
+
+BROWSER_TREE_RESULT = {
+    "categories": [
+        {
+            "name": "Instruments",
+            "uri": "browser:instruments",
+            "is_folder": True,
+            "is_loadable": False,
+            "children": [
+                {
+                    "name": "Synths",
+                    "uri": "browser:instruments/synths",
+                    "is_folder": True,
+                    "is_loadable": False,
+                    "children": [
+                        {
+                            "name": "Analog",
+                            "uri": "browser:instruments/synths/analog",
+                            "is_folder": False,
+                            "is_loadable": True,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+}
+
+BROWSER_ITEMS_RESULT = {
+    "path": "instruments/Synths",
+    "items": [
+        {
+            "name": "Analog",
+            "uri": "browser:instruments/synths/analog",
+            "is_loadable": True,
+        },
+        {
+            "name": "Operator",
+            "uri": "browser:instruments/synths/operator",
+            "is_loadable": True,
+        },
+    ],
+}
+
+BROWSER_SEARCH_RESULT = {
+    "query": "Analog",
+    "category": "instruments",
+    "items": [
+        {
+            "name": "Analog",
+            "path": "instruments/Synths/Analog",
+            "uri": "browser:instruments/synths/analog",
+            "is_loadable": True,
+        }
+    ],
+}
+
+
+def _ok_response(result: dict, request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_get_browser_tree_schema(self) -> None:
+        tool = self._get_tool("get_browser_tree")
+        props = tool.parameters["properties"]
+        assert props["category"]["default"] == "all"
+        assert props["category"]["enum"] == [
+            "all",
+            "instruments",
+            "sounds",
+            "drums",
+            "audio_effects",
+            "midi_effects",
+        ]
+
+    def test_get_browser_items_schema(self) -> None:
+        tool = self._get_tool("get_browser_items")
+        props = tool.parameters["properties"]
+        assert props["path"]["minLength"] == 1
+
+    def test_search_browser_schema(self) -> None:
+        tool = self._get_tool("search_browser")
+        props = tool.parameters["properties"]
+        assert props["query"]["minLength"] == 1
+        assert props["category"]["default"] == "all"
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    def test_get_browser_tree_rejects_unknown_category(self) -> None:
+        model = self._arg_model("get_browser_tree")
+        with pytest.raises(ValidationError):
+            model(category="plugins")
+
+    def test_get_browser_items_rejects_empty_path(self) -> None:
+        model = self._arg_model("get_browser_items")
+        with pytest.raises(ValidationError):
+            model(path="")
+
+    def test_search_browser_rejects_empty_query(self) -> None:
+        model = self._arg_model("search_browser")
+        with pytest.raises(ValidationError):
+            model(query="")
+
+
+class TestGetBrowserTree:
+    async def test_returns_tree(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(BROWSER_TREE_RESULT)
+
+        result = await get_browser_tree(ctx=mock_context)
+
+        assert isinstance(result, BrowserTree)
+        assert result.categories[0].name == "Instruments"
+        assert result.categories[0].children[0].children[0].name == "Analog"
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(BROWSER_TREE_RESULT)
+
+        await get_browser_tree(ctx=mock_context, category="drums")
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "browser.get_tree"
+        assert req.params == {"category": "drums"}
+
+
+class TestGetBrowserItems:
+    async def test_returns_items(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(BROWSER_ITEMS_RESULT)
+
+        result = await get_browser_items(ctx=mock_context, path="instruments/Synths")
+
+        assert isinstance(result, BrowserItemsResult)
+        assert result.path == "instruments/Synths"
+        assert result.items[0].name == "Analog"
+        assert result.items[1].is_loadable is True
+
+    async def test_raises_on_not_found(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Browser path not found: instruments/Missing",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_browser_items(ctx=mock_context, path="instruments/Missing")
+
+
+class TestSearchBrowser:
+    async def test_returns_results(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(BROWSER_SEARCH_RESULT)
+
+        result = await search_browser(
+            ctx=mock_context,
+            query="Analog",
+            category="instruments",
+        )
+
+        assert isinstance(result, BrowserSearchResult)
+        assert result.query == "Analog"
+        assert result.category == "instruments"
+        assert result.items[0].path == "instruments/Synths/Analog"
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(BROWSER_SEARCH_RESULT)
+
+        await search_browser(
+            ctx=mock_context,
+            query="Analog",
+            category="instruments",
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "browser.search"
+        assert req.params == {"query": "Analog", "category": "instruments"}
+
+    async def test_empty_results_are_allowed(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"query": "zzz", "category": "all", "items": []},
+        )
+
+        result = await search_browser(ctx=mock_context, query="zzz")
+
+        assert result.items == []

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -498,6 +498,8 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `set_device_parameter` | `device.set_parameter` |
 | `load_instrument` | `browser.load_instrument` |
 | `get_browser_tree` | `browser.get_tree` |
+| `get_browser_items` | `browser.get_items` |
+| `search_browser` | `browser.search` |
 
 ### Threading model (same as competitors, proven pattern)
 

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -50,6 +50,7 @@ class AbletonLiveMCP(ControlSurface):
 
     def _register_handlers(self) -> None:
         """Register command handlers with the dispatcher."""
+        from .handlers.browser import BrowserHandler
         from .handlers.clip import ClipHandler
         from .handlers.session import SessionHandler
         from .handlers.track import TrackHandler
@@ -57,6 +58,7 @@ class AbletonLiveMCP(ControlSurface):
         self._dispatcher.register("session", SessionHandler(self))
         self._dispatcher.register("track", TrackHandler(self))
         self._dispatcher.register("clip", ClipHandler(self))
+        self._dispatcher.register("browser", BrowserHandler(self))
 
     def disconnect(self) -> None:
         """Ableton lifecycle hook -- shut down the TCP server."""

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -4,8 +4,9 @@ Handler modules (session, track, clip, etc.) will be added by subsequent
 issues as the tool surface grows.
 """
 
+from .browser import BrowserHandler
 from .clip import ClipHandler
 from .session import SessionHandler
 from .track import TrackHandler
 
-__all__ = ["ClipHandler", "SessionHandler", "TrackHandler"]
+__all__ = ["BrowserHandler", "ClipHandler", "SessionHandler", "TrackHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/browser.py
+++ b/remote_script/AbletonLiveMCP/handlers/browser.py
@@ -1,0 +1,246 @@
+"""Browser command handlers for Ableton Live's content Browser."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+BROWSER_TREE_DEPTH = 2
+SUPPORTED_BROWSER_CATEGORIES = (
+    "instruments",
+    "sounds",
+    "drums",
+    "audio_effects",
+    "midi_effects",
+)
+
+
+class BrowserHandler(BaseHandler):
+    """Handle Browser navigation and search commands."""
+
+    def _browser(self) -> Any:
+        """Return Ableton's Browser object."""
+        application = self._control_surface.application()
+        browser = getattr(application, "browser", None)
+        if browser is None:
+            raise RuntimeError("Ableton Browser is not available")
+        return browser
+
+    def _normalize_category(
+        self,
+        raw_value: Any,
+        *,
+        allow_all: bool = False,
+    ) -> str:
+        """Validate and normalize a category name."""
+        if raw_value is None:
+            return "all" if allow_all else ""
+        if not isinstance(raw_value, str):
+            raise InvalidParamsError("'category' must be a string")
+
+        category = raw_value.strip().lower()
+        if not category:
+            raise InvalidParamsError("'category' must not be empty")
+        if category == "all":
+            if allow_all:
+                return category
+            raise InvalidParamsError("'category' must not be 'all' in this context")
+        if category not in SUPPORTED_BROWSER_CATEGORIES:
+            supported = ", ".join(SUPPORTED_BROWSER_CATEGORIES)
+            raise InvalidParamsError(
+                f"'category' must be one of: all, {supported}"
+                if allow_all
+                else f"'category' must be one of: {supported}"
+            )
+        return category
+
+    def _require_non_empty_string(self, raw_value: Any, name: str) -> str:
+        """Validate a required non-empty string parameter."""
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if not isinstance(raw_value, str):
+            raise InvalidParamsError(f"'{name}' must be a string")
+
+        value = raw_value.strip()
+        if not value:
+            raise InvalidParamsError(f"'{name}' must not be empty")
+        return value
+
+    def _root_categories(
+        self,
+        browser: Any,
+        category: str,
+    ) -> list[tuple[str, Any]]:
+        """Return the Browser root categories to inspect."""
+        if category == "all":
+            return [
+                (category_name, self._root_item(browser, category_name))
+                for category_name in SUPPORTED_BROWSER_CATEGORIES
+            ]
+        return [(category, self._root_item(browser, category))]
+
+    def _root_item(self, browser: Any, category: str) -> Any:
+        """Return one top-level Browser category object."""
+        normalized_category = self._normalize_category(category)
+        item = getattr(browser, normalized_category, None)
+        if item is None:
+            raise NotFoundError(
+                f"Browser category '{normalized_category}' is not available"
+            )
+        return item
+
+    def _children(self, item: Any) -> list[Any]:
+        """Return a materialized child list for a Browser item."""
+        raw_children = getattr(item, "children", [])
+        if raw_children is None:
+            return []
+        return list(raw_children)
+
+    def _serialize_tree_item(self, item: Any, depth: int) -> dict[str, Any]:
+        """Serialize a Browser item for tree output."""
+        children = self._children(item)
+        payload = {
+            "name": str(getattr(item, "name", "")),
+            "uri": self._item_uri(item),
+            "is_folder": bool(getattr(item, "is_folder", False) or children),
+            "is_loadable": bool(getattr(item, "is_loadable", False)),
+            "children": [],
+        }
+
+        if depth < BROWSER_TREE_DEPTH:
+            payload["children"] = [
+                self._serialize_tree_item(child, depth + 1) for child in children
+            ]
+
+        return payload
+
+    def _serialize_browser_item(self, item: Any) -> dict[str, Any]:
+        """Serialize a Browser item for flat list output."""
+        return {
+            "name": str(getattr(item, "name", "")),
+            "uri": self._item_uri(item),
+            "is_loadable": bool(getattr(item, "is_loadable", False)),
+        }
+
+    def _item_uri(self, item: Any) -> str | None:
+        """Return a string URI when available."""
+        uri = getattr(item, "uri", None)
+        if uri is None:
+            return None
+        return str(uri)
+
+    def _resolve_path(self, browser: Any, path: str) -> tuple[Any, str]:
+        """Resolve a slash-separated Browser path."""
+        parts = [part.strip() for part in path.split("/") if part.strip()]
+        if not parts:
+            raise InvalidParamsError("'path' must not be empty")
+
+        root_name = parts[0].lower()
+        current = self._root_item(browser, root_name)
+        normalized_parts = [root_name]
+
+        for raw_part in parts[1:]:
+            match = next(
+                (
+                    child
+                    for child in self._children(current)
+                    if str(getattr(child, "name", "")).lower() == raw_part.lower()
+                ),
+                None,
+            )
+            if match is None:
+                raise NotFoundError(f"Browser path not found: {path}")
+            current = match
+            normalized_parts.append(str(getattr(match, "name", "")))
+
+        return current, "/".join(normalized_parts)
+
+    def _search_item(
+        self,
+        item: Any,
+        *,
+        query: str,
+        path: str,
+        results: list[dict[str, Any]],
+    ) -> None:
+        """Recursively collect Browser items whose names match the query."""
+        name = str(getattr(item, "name", ""))
+        if query in name.lower():
+            results.append(
+                {
+                    "name": name,
+                    "path": path,
+                    "uri": self._item_uri(item),
+                    "is_loadable": bool(getattr(item, "is_loadable", False)),
+                }
+            )
+
+        for child in self._children(item):
+            child_name = str(getattr(child, "name", ""))
+            child_path = f"{path}/{child_name}"
+            self._search_item(child, query=query, path=child_path, results=results)
+
+    def handle_get_tree(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return a fixed-depth Browser tree."""
+        category = self._normalize_category(
+            params.get("category", "all"),
+            allow_all=True,
+        )
+
+        def _read() -> dict[str, Any]:
+            browser = self._browser()
+            categories = [
+                self._serialize_tree_item(item, depth=0)
+                for _slug, item in self._root_categories(browser, category)
+            ]
+            return {"categories": categories}
+
+        return self._run_on_main_thread(_read)
+
+    def handle_get_items(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return the immediate children at a Browser path."""
+        path = self._require_non_empty_string(params.get("path"), "path")
+
+        def _read() -> dict[str, Any]:
+            browser = self._browser()
+            item, normalized_path = self._resolve_path(browser, path)
+            return {
+                "path": normalized_path,
+                "items": [
+                    self._serialize_browser_item(child)
+                    for child in self._children(item)
+                ],
+            }
+
+        return self._run_on_main_thread(_read)
+
+    def handle_search(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Search Browser items recursively by name."""
+        query = self._require_non_empty_string(params.get("query"), "query")
+        category = self._normalize_category(
+            params.get("category", "all"),
+            allow_all=True,
+        )
+
+        def _read() -> dict[str, Any]:
+            browser = self._browser()
+            results: list[dict[str, Any]] = []
+            for root_name, root_item in self._root_categories(browser, category):
+                self._search_item(
+                    root_item,
+                    query=query.lower(),
+                    path=root_name,
+                    results=results,
+                )
+            return {
+                "query": query,
+                "category": category,
+                "items": results,
+            }
+
+        return self._run_on_main_thread(_read)
+
+
+__all__ = ["BrowserHandler"]

--- a/src/mcp_ableton/connection.py
+++ b/src/mcp_ableton/connection.py
@@ -16,6 +16,7 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1.0
 PING_TIMEOUT = 5.0
 BUFFER_SIZE = 65536
+STREAM_LIMIT = 8 * 1024 * 1024
 
 
 class AbletonConnection:
@@ -85,7 +86,11 @@ class AbletonConnection:
         logger.info("Connecting to Ableton at %s:%d", self.host, self.port)
         try:
             self._reader, self._writer = await asyncio.wait_for(
-                asyncio.open_connection(self.host, self.port),
+                asyncio.open_connection(
+                    self.host,
+                    self.port,
+                    limit=STREAM_LIMIT,
+                ),
                 timeout=self.timeout,
             )
         except asyncio.TimeoutError:
@@ -171,6 +176,11 @@ class AbletonConnection:
             raise TimeoutError(
                 f"No response from Ableton within {effective_timeout}s"
             ) from None
+        except asyncio.LimitOverrunError:
+            raise RuntimeError(
+                "Response from Ableton exceeded the configured stream limit "
+                f"({STREAM_LIMIT} bytes)"
+            ) from None
         return CommandResponse.from_line(raw_line)
 
     async def ping(self) -> bool:
@@ -196,4 +206,5 @@ __all__ = [
     "DEFAULT_TIMEOUT",
     "BUFFER_SIZE",
     "PING_TIMEOUT",
+    "STREAM_LIMIT",
 ]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tool modules for the Ableton MCP server."""
 
+import mcp_ableton.tools.browser  # noqa: F401
 import mcp_ableton.tools.clip  # noqa: F401
 import mcp_ableton.tools.session  # noqa: F401
 import mcp_ableton.tools.track  # noqa: F401

--- a/src/mcp_ableton/tools/browser.py
+++ b/src/mcp_ableton/tools/browser.py
@@ -1,0 +1,174 @@
+"""MCP tools for browsing Ableton Live's Browser."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Literal
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+BrowserCategory = Literal[
+    "all",
+    "instruments",
+    "sounds",
+    "drums",
+    "audio_effects",
+    "midi_effects",
+]
+
+
+class BrowserTreeNode(BaseModel):
+    """Hierarchical Browser node returned by ``get_browser_tree``."""
+
+    name: str
+    uri: str | None = None
+    is_folder: bool
+    is_loadable: bool
+    children: list[BrowserTreeNode] = Field(default_factory=list)
+
+
+BrowserTreeNode.model_rebuild()
+
+
+class BrowserTree(BaseModel):
+    """Fixed-depth Browser tree rooted at one or more top-level categories."""
+
+    categories: list[BrowserTreeNode]
+
+
+class BrowserItem(BaseModel):
+    """Immediate child item returned by ``get_browser_items``."""
+
+    name: str
+    uri: str | None = None
+    is_loadable: bool
+
+
+class BrowserItemsResult(BaseModel):
+    """Immediate Browser children for a resolved path."""
+
+    path: str
+    items: list[BrowserItem]
+
+
+class BrowserSearchItem(BaseModel):
+    """One Browser search hit."""
+
+    name: str
+    path: str
+    uri: str | None = None
+    is_loadable: bool
+
+
+class BrowserSearchResult(BaseModel):
+    """Search results for ``search_browser``."""
+
+    query: str
+    category: BrowserCategory
+    items: list[BrowserSearchItem]
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    """Extract the AbletonConnection from the FastMCP context."""
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def get_browser_tree(
+    ctx: Context,
+    category: Annotated[
+        BrowserCategory,
+        Field(
+            description=(
+                "Browser root to inspect: one category or 'all' for every "
+                "supported Phase 1 Browser category."
+            ),
+        ),
+    ] = "all",
+) -> BrowserTree:
+    """Get a shallow hierarchical Browser tree for supported categories."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="browser.get_tree",
+        params={"category": category},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return BrowserTree.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_browser_items(
+    ctx: Context,
+    path: Annotated[
+        str,
+        Field(
+            description=(
+                "Slash-separated Browser path rooted at a supported category, "
+                "for example 'instruments' or 'instruments/Synths'."
+            ),
+            min_length=1,
+        ),
+    ],
+) -> BrowserItemsResult:
+    """Get the immediate Browser items at a slash-separated path."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="browser.get_items",
+        params={"path": path},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return BrowserItemsResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def search_browser(
+    ctx: Context,
+    query: Annotated[
+        str,
+        Field(
+            description="Case-insensitive Browser search query.",
+            min_length=1,
+        ),
+    ],
+    category: Annotated[
+        BrowserCategory,
+        Field(
+            description=(
+                "Browser root to search: one category or 'all' for every "
+                "supported Phase 1 Browser category."
+            ),
+        ),
+    ] = "all",
+) -> BrowserSearchResult:
+    """Search Browser items recursively by name."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="browser.search",
+        params={"query": query, "category": category},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return BrowserSearchResult.model_validate(response.result)
+
+
+__all__ = [
+    "BrowserItem",
+    "BrowserItemsResult",
+    "BrowserSearchItem",
+    "BrowserSearchResult",
+    "BrowserTree",
+    "BrowserTreeNode",
+    "get_browser_items",
+    "get_browser_tree",
+    "search_browser",
+]


### PR DESCRIPTION
## Summary

Implements the three Phase 1 browser tools from ADR-002 and issue **#14**: MCP layer (`tools/browser.py`), `browser.*` Remote Script handlers, browser-specific tests, and a transport fix discovered during live Ableton smoke testing.

## MCP tools

- `get_browser_tree(category="all")`
- `get_browser_items(path)`
- `search_browser(query, category="all")`
- Supported roots are limited to the Phase 1 ADR scope: `all`, `instruments`, `sounds`, `drums`, `audio_effects`, `midi_effects`
- `get_browser_tree` is intentionally fixed-depth (`2`) to keep Browser payloads usable over MCP
- `get_browser_items` resolves slash-separated Browser paths case-insensitively and returns `NOT_FOUND` for missing paths
- `search_browser` is case-insensitive and returns empty results rather than an error when nothing matches

## Remote Script

- Adds `BrowserHandler` and registers the `browser` category in the Control Surface lifecycle
- Browser reads run on Ableton’s main thread through `BaseHandler._run_on_main_thread`
- Adds private helpers for root-category lookup, fixed-depth tree serialization, path traversal, and recursive search
- Keeps instrument/effect loading out of scope for issue #12

## Transport

- In live Ableton testing, Browser payloads exceeded the default `asyncio` stream limit and caused MCP tool failures before the handler responses could be fully read
- Increases the MCP TCP client stream limit to `8 * 1024 * 1024` and adds a connection regression test so large Browser responses work end-to-end

## Tests

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest`
- [x] `Tests/tools/test_browser.py` for tool registration, schema, validation, request construction, and response handling
- [x] `Tests/test_browser_handler.py` for category validation, depth limiting, path traversal, search, and `NOT_FOUND`
- [x] `Tests/test_integration.py` round-trip coverage for nested browser payloads
- [x] `Tests/test_connection.py` regression coverage for the larger stream limit

## Manual verification

Validated against a real Ableton Live 12.2.5 instance with the `AbletonLiveMCP` Remote Script loaded on port `9877`, using the actual stdio MCP server process (`uv run mcp-ableton`) and an MCP stdio client:

- `get_session_info` succeeded with the live set (`tempo=120.0`, `track_count=4`)
- `get_browser_tree(category="all")` succeeded and returned 5 root categories: `Instruments`, `Sounds`, `Drums`, `Audio Effects`, `MIDI Effects`
- `get_browser_items(path="instruments")` succeeded and returned 23 immediate items; first five were `Analog`, `Collision`, `Drift`, `Drum Rack`, `Drum Sampler`
- `search_browser(query="Analog", category="instruments")` succeeded and returned 33 hits
- `get_browser_items(path="instruments/Definitely Missing")` returned structured `NOT_FOUND`
- `search_browser(query="zzzzzzzzzz", category="all")` returned an empty result set
- Ableton `Log.txt` showed only expected client connect/disconnect lines during the successful post-fix smoke run, with no Python traceback or exception entries

## Docs

- Refreshes the README status line to include the shipped Browser tools
- Extends ADR-002 command mapping with `get_browser_items -> browser.get_items` and `search_browser -> browser.search`

Closes #14
