### PR TITLE
Add device and parameter MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport**, **track management**, **session clip**, **MIDI note**, and **browser** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport**, **track management**, **session clip**, **MIDI note**, **browser**, and **device/parameter** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 

--- a/Tests/test_device_handler.py
+++ b/Tests/test_device_handler.py
@@ -1,0 +1,589 @@
+"""Tests for DeviceHandler and BrowserHandler device-loading commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from AbletonLiveMCP.dispatcher import Dispatcher, InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.browser import BrowserHandler
+from AbletonLiveMCP.handlers.device import DeviceHandler
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class _Parameter:
+    def __init__(
+        self,
+        name: str,
+        value: float,
+        minimum: float,
+        maximum: float,
+        *,
+        is_quantized: bool = False,
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.min = minimum
+        self.max = maximum
+        self.is_quantized = is_quantized
+
+
+class _Device:
+    def __init__(self, name: str, parameters: list[_Parameter]) -> None:
+        self.name = name
+        self.parameters = parameters
+
+
+class _Track:
+    def __init__(
+        self,
+        name: str,
+        *,
+        midi: bool,
+        audio: bool,
+        devices: list[_Device] | None = None,
+    ) -> None:
+        self.name = name
+        self.has_midi_input = midi
+        self.has_audio_input = audio
+        self.devices = devices or []
+
+
+class _SongView:
+    def __init__(self) -> None:
+        self.selected_track: _Track | None = None
+
+
+class _Song:
+    def __init__(self, tracks: list[_Track]) -> None:
+        self.tracks = tracks
+        self.view = _SongView()
+
+
+class _BrowserItem:
+    def __init__(
+        self,
+        name: str,
+        *,
+        uri: str | None = None,
+        is_loadable: bool = False,
+        device_factory: Callable[[], _Device] | None = None,
+        children: list[_BrowserItem] | None = None,
+    ) -> None:
+        self.name = name
+        self.uri = uri
+        self.is_loadable = is_loadable
+        self.device_factory = device_factory
+        self.children = children or []
+        self.is_folder = bool(self.children)
+
+
+class _Browser:
+    def __init__(self, song: _Song) -> None:
+        self._song = song
+        self.instruments = _BrowserItem(
+            "Instruments",
+            uri="browser:instruments",
+            children=[
+                _BrowserItem(
+                    "Synths",
+                    uri="browser:instruments/synths",
+                    children=[
+                        _BrowserItem(
+                            "Analog",
+                            uri="browser:instruments/synths/analog",
+                            is_loadable=True,
+                            device_factory=lambda: _Device(
+                                "Analog",
+                                [
+                                    _Parameter(
+                                        "Device On",
+                                        1.0,
+                                        0.0,
+                                        1.0,
+                                        is_quantized=True,
+                                    ),
+                                    _Parameter("Filter Freq", 5000.0, 20.0, 20000.0),
+                                ],
+                            ),
+                        ),
+                        _BrowserItem(
+                            "Broken Instrument",
+                            uri="browser:instruments/synths/broken",
+                            is_loadable=False,
+                        ),
+                    ],
+                )
+            ],
+        )
+        self.audio_effects = _BrowserItem(
+            "Audio Effects",
+            uri="browser:audio_effects",
+            children=[
+                _BrowserItem(
+                    "Filters",
+                    uri="browser:audio_effects/filters",
+                    children=[
+                        _BrowserItem(
+                            "Auto Filter",
+                            uri="browser:audio_effects/filters/auto-filter",
+                            is_loadable=True,
+                            device_factory=lambda: _Device(
+                                "Auto Filter",
+                                [
+                                    _Parameter(
+                                        "Device On",
+                                        1.0,
+                                        0.0,
+                                        1.0,
+                                        is_quantized=True,
+                                    ),
+                                    _Parameter("Frequency", 2500.0, 20.0, 20000.0),
+                                ],
+                            ),
+                        ),
+                        _BrowserItem(
+                            "Broken Effect",
+                            uri="browser:audio_effects/filters/broken",
+                            is_loadable=False,
+                        ),
+                    ],
+                )
+            ],
+        )
+        self.midi_effects = _BrowserItem(
+            "MIDI Effects",
+            uri="browser:midi_effects",
+            children=[
+                _BrowserItem(
+                    "Pitch",
+                    uri="browser:midi_effects/pitch",
+                    children=[],
+                )
+            ],
+        )
+
+    def load_item(self, item: _BrowserItem) -> None:
+        selected_track = self._song.view.selected_track
+        if selected_track is None:
+            raise RuntimeError("No selected track")
+        if item.device_factory is None:
+            return
+        selected_track.devices.append(item.device_factory())
+
+
+class _Application:
+    def __init__(self, song: _Song) -> None:
+        self.browser = _Browser(song)
+
+
+class _FakeControlSurface:
+    def __init__(self, song: _Song) -> None:
+        self._song = song
+        self._application = _Application(song)
+
+    def application(self) -> _Application:
+        return self._application
+
+    def song(self) -> _Song:
+        return self._song
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay: int, callback) -> None:
+        callback()
+
+
+@pytest.fixture
+def song() -> _Song:
+    return _Song(
+        [
+            _Track(
+                "MIDI Track",
+                midi=True,
+                audio=False,
+                devices=[
+                    _Device(
+                        "Utility",
+                        [
+                            _Parameter("Gain", 0.0, -35.0, 35.0),
+                            _Parameter("Mute", 0.0, 0.0, 1.0, is_quantized=True),
+                        ],
+                    ),
+                    _Device(
+                        "Analog",
+                        [
+                            _Parameter("Device On", 1.0, 0.0, 1.0, is_quantized=True),
+                            _Parameter("Filter Freq", 5000.0, 20.0, 20000.0),
+                        ],
+                    ),
+                ],
+            ),
+            _Track(
+                "Audio Track",
+                midi=False,
+                audio=True,
+                devices=[
+                    _Device(
+                        "EQ Eight",
+                        [
+                            _Parameter("Device On", 1.0, 0.0, 1.0, is_quantized=True),
+                            _Parameter("Gain A", 0.0, -15.0, 15.0),
+                        ],
+                    )
+                ],
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def control_surface(song: _Song) -> _FakeControlSurface:
+    return _FakeControlSurface(song)
+
+
+@pytest.fixture
+def device_handler(control_surface: _FakeControlSurface) -> DeviceHandler:
+    return DeviceHandler(control_surface)
+
+
+@pytest.fixture
+def browser_handler(control_surface: _FakeControlSurface) -> BrowserHandler:
+    return BrowserHandler(control_surface)
+
+
+class TestGetParameters:
+    def test_parameter_serialization_shape(self, device_handler: DeviceHandler) -> None:
+        result = device_handler.handle_get_parameters(
+            {"track_index": 1, "device_index": 2}
+        )
+
+        assert result["track_index"] == 1
+        assert result["device_index"] == 2
+        assert result["device_name"] == "Analog"
+        assert result["parameters"] == [
+            {
+                "parameter_index": 1,
+                "name": "Device On",
+                "value": 1.0,
+                "min": 0.0,
+                "max": 1.0,
+                "is_quantized": True,
+            },
+            {
+                "parameter_index": 2,
+                "name": "Filter Freq",
+                "value": 5000.0,
+                "min": 20.0,
+                "max": 20000.0,
+                "is_quantized": False,
+            },
+        ]
+
+    def test_uses_one_based_device_addressing(
+        self,
+        device_handler: DeviceHandler,
+    ) -> None:
+        result = device_handler.handle_get_parameters(
+            {"track_index": 1, "device_index": 1}
+        )
+
+        assert result["device_name"] == "Utility"
+        assert result["parameters"][1]["name"] == "Mute"
+
+
+class TestSetParameter:
+    def test_parameter_set_success(
+        self,
+        device_handler: DeviceHandler,
+        song: _Song,
+    ) -> None:
+        result = device_handler.handle_set_parameter(
+            {
+                "track_index": 1,
+                "device_index": 2,
+                "parameter_index": 2,
+                "value": 1200.0,
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "device_index": 2,
+            "parameter_index": 2,
+            "value": 1200.0,
+        }
+        assert song.tracks[0].devices[1].parameters[1].value == 1200.0
+
+    def test_uses_one_based_parameter_addressing(
+        self,
+        device_handler: DeviceHandler,
+        song: _Song,
+    ) -> None:
+        device_handler.handle_set_parameter(
+            {
+                "track_index": 1,
+                "device_index": 1,
+                "parameter_index": 2,
+                "value": 1.0,
+            }
+        )
+
+        assert song.tracks[0].devices[0].parameters[1].value == 1.0
+        assert song.tracks[0].devices[0].parameters[0].value == 0.0
+
+    def test_out_of_range_value_rejected(self, device_handler: DeviceHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="between 20.0 and 20000.0"):
+            device_handler.handle_set_parameter(
+                {
+                    "track_index": 1,
+                    "device_index": 2,
+                    "parameter_index": 2,
+                    "value": 25000.0,
+                }
+            )
+
+    def test_missing_device_raises_not_found(
+        self,
+        device_handler: DeviceHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="Device 9"):
+            device_handler.handle_set_parameter(
+                {
+                    "track_index": 1,
+                    "device_index": 9,
+                    "parameter_index": 1,
+                    "value": 0.0,
+                }
+            )
+
+    def test_missing_parameter_raises_not_found(
+        self,
+        device_handler: DeviceHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="Parameter 9"):
+            device_handler.handle_set_parameter(
+                {
+                    "track_index": 1,
+                    "device_index": 1,
+                    "parameter_index": 9,
+                    "value": 0.0,
+                }
+            )
+
+
+class TestLoadInstrument:
+    def test_load_instrument_success_on_midi_track(
+        self,
+        browser_handler: BrowserHandler,
+        song: _Song,
+    ) -> None:
+        before_count = len(song.tracks[0].devices)
+
+        result = browser_handler.handle_load_instrument(
+            {
+                "track_index": 1,
+                "uri": "browser:instruments/synths/analog",
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "device_index": before_count + 1,
+            "name": "Analog",
+            "uri": "browser:instruments/synths/analog",
+        }
+        assert song.view.selected_track is song.tracks[0]
+        assert song.tracks[0].devices[-1].name == "Analog"
+
+    def test_load_instrument_rejects_audio_track(
+        self,
+        browser_handler: BrowserHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="must be a MIDI track"):
+            browser_handler.handle_load_instrument(
+                {
+                    "track_index": 2,
+                    "uri": "browser:instruments/synths/analog",
+                }
+            )
+
+    def test_load_instrument_uri_not_found(
+        self,
+        browser_handler: BrowserHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="Browser item not found"):
+            browser_handler.handle_load_instrument(
+                {
+                    "track_index": 1,
+                    "uri": "browser:instruments/synths/missing",
+                }
+            )
+
+    def test_load_instrument_non_loadable_uri_rejected(
+        self,
+        browser_handler: BrowserHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="not loadable"):
+            browser_handler.handle_load_instrument(
+                {
+                    "track_index": 1,
+                    "uri": "browser:instruments/synths/broken",
+                }
+            )
+
+
+class TestLoadEffect:
+    def test_load_effect_position_minus_one_success(
+        self,
+        browser_handler: BrowserHandler,
+        song: _Song,
+    ) -> None:
+        before_count = len(song.tracks[1].devices)
+
+        result = browser_handler.handle_load_effect(
+            {
+                "track_index": 2,
+                "uri": "browser:audio_effects/filters/auto-filter",
+                "position": -1,
+            }
+        )
+
+        assert result == {
+            "track_index": 2,
+            "device_index": before_count + 1,
+            "name": "Auto Filter",
+            "uri": "browser:audio_effects/filters/auto-filter",
+        }
+        assert song.tracks[1].devices[-1].name == "Auto Filter"
+
+    def test_load_effect_handles_rewrapped_existing_devices(
+        self,
+        browser_handler: BrowserHandler,
+        song: _Song,
+    ) -> None:
+        browser = browser_handler._browser()
+
+        def _reload_wrapped_devices(item: _BrowserItem) -> None:
+            selected_track = song.view.selected_track
+            assert selected_track is not None
+            rebuilt_devices = [
+                _Device(
+                    existing_device.name,
+                    [
+                        _Parameter(
+                            parameter.name,
+                            parameter.value,
+                            parameter.min,
+                            parameter.max,
+                            is_quantized=parameter.is_quantized,
+                        )
+                        for parameter in existing_device.parameters
+                    ],
+                )
+                for existing_device in selected_track.devices
+            ]
+            if item.device_factory is not None:
+                rebuilt_devices.append(item.device_factory())
+            selected_track.devices = rebuilt_devices
+
+        browser.load_item = _reload_wrapped_devices
+
+        result = browser_handler.handle_load_effect(
+            {
+                "track_index": 2,
+                "uri": "browser:audio_effects/filters/auto-filter",
+                "position": -1,
+            }
+        )
+
+        assert result["device_index"] == 2
+        assert result["name"] == "Auto Filter"
+
+    def test_load_effect_uri_not_found(self, browser_handler: BrowserHandler) -> None:
+        with pytest.raises(NotFoundError, match="Browser item not found"):
+            browser_handler.handle_load_effect(
+                {
+                    "track_index": 1,
+                    "uri": "browser:audio_effects/filters/missing",
+                    "position": -1,
+                }
+            )
+
+    def test_load_effect_non_loadable_uri_rejected(
+        self,
+        browser_handler: BrowserHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="not loadable"):
+            browser_handler.handle_load_effect(
+                {
+                    "track_index": 1,
+                    "uri": "browser:audio_effects/filters/broken",
+                    "position": -1,
+                }
+            )
+
+
+class TestDispatcherIntegration:
+    def test_missing_device_maps_to_not_found(
+        self,
+        control_surface: _FakeControlSurface,
+    ) -> None:
+        dispatcher = Dispatcher(control_surface)
+        dispatcher.register("device", DeviceHandler(control_surface))
+
+        response = dispatcher.dispatch(
+            "device.get_parameters",
+            {"track_index": 1, "device_index": 9},
+            "device-1",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+        assert "Device 9" in response["error"]["message"]
+
+    def test_missing_parameter_maps_to_not_found(
+        self,
+        control_surface: _FakeControlSurface,
+    ) -> None:
+        dispatcher = Dispatcher(control_surface)
+        dispatcher.register("device", DeviceHandler(control_surface))
+
+        response = dispatcher.dispatch(
+            "device.set_parameter",
+            {
+                "track_index": 1,
+                "device_index": 1,
+                "parameter_index": 99,
+                "value": 0.0,
+            },
+            "device-2",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+        assert "Parameter 99" in response["error"]["message"]
+
+    def test_load_effect_position_zero_maps_to_invalid_params(
+        self,
+        control_surface: _FakeControlSurface,
+    ) -> None:
+        dispatcher = Dispatcher(control_surface)
+        dispatcher.register("browser", BrowserHandler(control_surface))
+
+        response = dispatcher.dispatch(
+            "browser.load_effect",
+            {
+                "track_index": 1,
+                "uri": "browser:audio_effects/filters/auto-filter",
+                "position": 0,
+            },
+            "browser-1",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "INVALID_PARAMS"
+        assert "unsupported on the Live 12.2.5 runtime" in response["error"]["message"]

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -58,6 +58,33 @@ class _BrowserHandler:
         }
 
 
+class _DeviceHandler:
+    def handle_get_parameters(self, params):
+        return {
+            "track_index": 1,
+            "device_index": 2,
+            "device_name": "Analog",
+            "parameters": [
+                {
+                    "parameter_index": 1,
+                    "name": "Device On",
+                    "value": 1.0,
+                    "min": 0.0,
+                    "max": 1.0,
+                    "is_quantized": True,
+                },
+                {
+                    "parameter_index": 2,
+                    "name": "Filter Freq",
+                    "value": 5000.0,
+                    "min": 20.0,
+                    "max": 20000.0,
+                    "is_quantized": False,
+                },
+            ],
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
@@ -65,6 +92,7 @@ def tcp_server():
     dispatcher = Dispatcher(cs)
     dispatcher.register("session", _EchoHandler())
     dispatcher.register("browser", _BrowserHandler())
+    dispatcher.register("device", _DeviceHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -149,5 +177,22 @@ class TestFullRoundTrip:
         category = resp.result["categories"][0]
         assert category["name"] == "Instruments"
         assert category["children"][0]["children"][0]["name"] == "Analog"
+
+        await conn.disconnect()
+
+    async def test_device_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="device.get_parameters", id="device-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "device-1"
+        assert resp.result is not None
+        assert resp.result["device_name"] == "Analog"
+        assert resp.result["parameters"][0]["parameter_index"] == 1
+        assert resp.result["parameters"][1]["name"] == "Filter Freq"
 
         await conn.disconnect()

--- a/Tests/tools/test_device.py
+++ b/Tests/tools/test_device.py
@@ -1,0 +1,392 @@
+"""Tests for device and parameter MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.device import (
+    DeviceParametersResult,
+    EffectLoadedResult,
+    InstrumentLoadedResult,
+    ParameterSetResult,
+    get_device_parameters,
+    load_effect,
+    load_instrument,
+    set_device_parameter,
+)
+
+TOOL_NAMES = [
+    "get_device_parameters",
+    "set_device_parameter",
+    "load_instrument",
+    "load_effect",
+]
+
+DEVICE_PARAMETERS_RESULT = {
+    "track_index": 1,
+    "device_index": 2,
+    "device_name": "Analog",
+    "parameters": [
+        {
+            "parameter_index": 1,
+            "name": "Device On",
+            "value": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "is_quantized": True,
+        },
+        {
+            "parameter_index": 2,
+            "name": "Filter Freq",
+            "value": 5500.0,
+            "min": 20.0,
+            "max": 20000.0,
+            "is_quantized": False,
+        },
+    ],
+}
+
+PARAMETER_SET_RESULT = {
+    "track_index": 1,
+    "device_index": 2,
+    "parameter_index": 2,
+    "value": 1200.0,
+}
+
+INSTRUMENT_LOADED_RESULT = {
+    "track_index": 1,
+    "device_index": 2,
+    "name": "Analog",
+    "uri": "browser:instruments/synths/analog",
+}
+
+EFFECT_LOADED_RESULT = {
+    "track_index": 1,
+    "device_index": 3,
+    "name": "Auto Filter",
+    "uri": "browser:audio_effects/filters/auto-filter",
+}
+
+
+def _ok_response(result: dict, request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_get_device_parameters_schema(self) -> None:
+        tool = self._get_tool("get_device_parameters")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["device_index"]["minimum"] == 1
+
+    def test_set_device_parameter_schema(self) -> None:
+        tool = self._get_tool("set_device_parameter")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["device_index"]["minimum"] == 1
+        assert props["parameter_index"]["minimum"] == 1
+
+    def test_load_instrument_schema(self) -> None:
+        tool = self._get_tool("load_instrument")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["uri"]["minLength"] == 1
+
+    def test_load_effect_schema(self) -> None:
+        tool = self._get_tool("load_effect")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["uri"]["minLength"] == 1
+        assert props["position"]["default"] == -1
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    def test_get_device_parameters_rejects_non_positive_indices(self) -> None:
+        model = self._arg_model("get_device_parameters")
+        with pytest.raises(ValidationError):
+            model(track_index=0, device_index=1)
+        with pytest.raises(ValidationError):
+            model(track_index=1, device_index=0)
+
+    def test_set_device_parameter_rejects_non_positive_parameter_index(self) -> None:
+        model = self._arg_model("set_device_parameter")
+        with pytest.raises(ValidationError):
+            model(
+                track_index=1,
+                device_index=1,
+                parameter_index=0,
+                value=1.0,
+            )
+
+    def test_load_instrument_rejects_empty_uri(self) -> None:
+        model = self._arg_model("load_instrument")
+        with pytest.raises(ValidationError):
+            model(track_index=1, uri="")
+
+    def test_load_effect_defaults_position_to_minus_one(self) -> None:
+        model = self._arg_model("load_effect")
+        args = model(track_index=1, uri="browser:audio_effects/filters/auto-filter")
+        assert args.position == -1
+
+
+class TestGetDeviceParameters:
+    async def test_returns_parameters(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            DEVICE_PARAMETERS_RESULT
+        )
+
+        result = await get_device_parameters(
+            ctx=mock_context,
+            track_index=1,
+            device_index=2,
+        )
+
+        assert isinstance(result, DeviceParametersResult)
+        assert result.device_name == "Analog"
+        assert result.parameters[1].parameter_index == 2
+        assert result.parameters[1].value == 5500.0
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            DEVICE_PARAMETERS_RESULT
+        )
+
+        await get_device_parameters(
+            ctx=mock_context,
+            track_index=3,
+            device_index=4,
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "device.get_parameters"
+        assert req.params == {"track_index": 3, "device_index": 4}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Device 9 does not exist on track 1",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_device_parameters(
+                ctx=mock_context,
+                track_index=1,
+                device_index=9,
+            )
+
+
+class TestSetDeviceParameter:
+    async def test_returns_parameter_set_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(PARAMETER_SET_RESULT)
+
+        result = await set_device_parameter(
+            ctx=mock_context,
+            track_index=1,
+            device_index=2,
+            parameter_index=2,
+            value=1200.0,
+        )
+
+        assert isinstance(result, ParameterSetResult)
+        assert result.parameter_index == 2
+        assert result.value == 1200.0
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(PARAMETER_SET_RESULT)
+
+        await set_device_parameter(
+            ctx=mock_context,
+            track_index=5,
+            device_index=2,
+            parameter_index=7,
+            value=0.5,
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "device.set_parameter"
+        assert req.params == {
+            "track_index": 5,
+            "device_index": 2,
+            "parameter_index": 7,
+            "value": 0.5,
+        }
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message="'value' must be between 0.0 and 1.0, got 2.0",
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await set_device_parameter(
+                ctx=mock_context,
+                track_index=1,
+                device_index=1,
+                parameter_index=1,
+                value=2.0,
+            )
+
+
+class TestLoadInstrument:
+    async def test_returns_instrument_load_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            INSTRUMENT_LOADED_RESULT
+        )
+
+        result = await load_instrument(
+            ctx=mock_context,
+            track_index=1,
+            uri="browser:instruments/synths/analog",
+        )
+
+        assert isinstance(result, InstrumentLoadedResult)
+        assert result.device_index == 2
+        assert result.name == "Analog"
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            INSTRUMENT_LOADED_RESULT
+        )
+
+        await load_instrument(
+            ctx=mock_context,
+            track_index=2,
+            uri="browser:instruments/synths/operator",
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "browser.load_instrument"
+        assert req.params == {
+            "track_index": 2,
+            "uri": "browser:instruments/synths/operator",
+        }
+
+
+class TestLoadEffect:
+    async def test_returns_effect_load_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(EFFECT_LOADED_RESULT)
+
+        result = await load_effect(
+            ctx=mock_context,
+            track_index=1,
+            uri="browser:audio_effects/filters/auto-filter",
+        )
+
+        assert isinstance(result, EffectLoadedResult)
+        assert result.device_index == 3
+        assert result.name == "Auto Filter"
+
+    async def test_sends_correct_command_with_default_position(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(EFFECT_LOADED_RESULT)
+
+        await load_effect(
+            ctx=mock_context,
+            track_index=4,
+            uri="browser:midi_effects/pitch/chord",
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "browser.load_effect"
+        assert req.params == {
+            "track_index": 4,
+            "uri": "browser:midi_effects/pitch/chord",
+            "position": -1,
+        }
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message=(
+                "Arbitrary effect insertion is unsupported on the Live 12.2.5 "
+                "runtime; use position=-1"
+            ),
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await load_effect(
+                ctx=mock_context,
+                track_index=1,
+                uri="browser:audio_effects/filters/auto-filter",
+                position=0,
+            )

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -497,6 +497,7 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `get_device_parameters` | `device.get_parameters` |
 | `set_device_parameter` | `device.set_parameter` |
 | `load_instrument` | `browser.load_instrument` |
+| `load_effect` | `browser.load_effect` |
 | `get_browser_tree` | `browser.get_tree` |
 | `get_browser_items` | `browser.get_items` |
 | `search_browser` | `browser.search` |

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -52,11 +52,13 @@ class AbletonLiveMCP(ControlSurface):
         """Register command handlers with the dispatcher."""
         from .handlers.browser import BrowserHandler
         from .handlers.clip import ClipHandler
+        from .handlers.device import DeviceHandler
         from .handlers.session import SessionHandler
         from .handlers.track import TrackHandler
 
         self._dispatcher.register("session", SessionHandler(self))
         self._dispatcher.register("track", TrackHandler(self))
+        self._dispatcher.register("device", DeviceHandler(self))
         self._dispatcher.register("clip", ClipHandler(self))
         self._dispatcher.register("browser", BrowserHandler(self))
 
@@ -65,3 +67,6 @@ class AbletonLiveMCP(ControlSurface):
         self.log_message("AbletonLiveMCP: shutting down")
         self._tcp_server.shutdown()
         ControlSurface.disconnect(self)
+
+
+__all__ = ["AbletonLiveMCP", "TCP_HOST", "TCP_PORT", "create_instance"]

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -6,7 +6,14 @@ issues as the tool surface grows.
 
 from .browser import BrowserHandler
 from .clip import ClipHandler
+from .device import DeviceHandler
 from .session import SessionHandler
 from .track import TrackHandler
 
-__all__ = ["BrowserHandler", "ClipHandler", "SessionHandler", "TrackHandler"]
+__all__ = [
+    "BrowserHandler",
+    "ClipHandler",
+    "DeviceHandler",
+    "SessionHandler",
+    "TrackHandler",
+]

--- a/remote_script/AbletonLiveMCP/handlers/browser.py
+++ b/remote_script/AbletonLiveMCP/handlers/browser.py
@@ -68,6 +68,27 @@ class BrowserHandler(BaseHandler):
             raise InvalidParamsError(f"'{name}' must not be empty")
         return value
 
+    def _require_track_index(self, params: dict[str, Any]) -> int:
+        """Validate a 1-based track index parameter."""
+        raw_value = params.get("track_index")
+        if raw_value is None:
+            raise InvalidParamsError("'track_index' parameter is required")
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            raise InvalidParamsError("'track_index' must be an integer")
+        if raw_value < 1:
+            raise InvalidParamsError("'track_index' must be at least 1")
+        return raw_value
+
+    def _resolve_track(self, track_index: int) -> Any:
+        """Resolve a 1-based track index."""
+        tracks = self._song.tracks
+        track_count = len(tracks)
+        if track_index > track_count:
+            raise NotFoundError(
+                f"Track {track_index} does not exist (song has {track_count} track(s))"
+            )
+        return tracks[track_index - 1]
+
     def _root_categories(
         self,
         browser: Any,
@@ -130,6 +151,55 @@ class BrowserHandler(BaseHandler):
         if uri is None:
             return None
         return str(uri)
+
+    def _find_item_by_uri(self, item: Any, uri: str) -> Any | None:
+        """Recursively search a Browser subtree for a matching URI."""
+        if self._item_uri(item) == uri:
+            return item
+
+        for child in self._children(item):
+            match = self._find_item_by_uri(child, uri)
+            if match is not None:
+                return match
+
+        return None
+
+    def _find_item_in_roots(self, roots: list[Any], uri: str) -> Any | None:
+        """Search multiple Browser roots for a matching URI."""
+        for root in roots:
+            match = self._find_item_by_uri(root, uri)
+            if match is not None:
+                return match
+        return None
+
+    def _device_signature(self, device: Any) -> tuple[str, str]:
+        """Return a stable-enough signature for Browser load diffing."""
+        return (
+            str(getattr(device, "name", "")),
+            str(getattr(device, "class_name", "")),
+        )
+
+    def _infer_loaded_device(
+        self,
+        before_devices: list[Any],
+        after_devices: list[Any],
+    ) -> Any:
+        """Infer which device was inserted from before/after device sequences."""
+        if len(after_devices) <= len(before_devices):
+            raise RuntimeError("Browser load completed but no new device appeared")
+
+        before_signatures = [
+            self._device_signature(device) for device in before_devices
+        ]
+        after_signatures = [self._device_signature(device) for device in after_devices]
+
+        if len(after_devices) == len(before_devices) + 1:
+            for index in range(len(after_devices) - 1, -1, -1):
+                candidate = after_signatures[:index] + after_signatures[index + 1 :]
+                if candidate == before_signatures:
+                    return after_devices[index]
+
+        return after_devices[-1]
 
     def _resolve_path(self, browser: Any, path: str) -> tuple[Any, str]:
         """Resolve a slash-separated Browser path."""
@@ -241,6 +311,84 @@ class BrowserHandler(BaseHandler):
             }
 
         return self._run_on_main_thread(_read)
+
+    def handle_load_instrument(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Load an instrument onto a MIDI track from the instruments Browser root."""
+        track_index = self._require_track_index(params)
+        uri = self._require_non_empty_string(params.get("uri"), "uri")
+
+        def _load() -> dict[str, Any]:
+            browser = self._browser()
+            track = self._resolve_track(track_index)
+            if not bool(getattr(track, "has_midi_input", False)):
+                raise InvalidParamsError(
+                    f"Track {track_index} must be a MIDI track to load an instrument"
+                )
+
+            item = self._find_item_in_roots([browser.instruments], uri)
+            if item is None:
+                raise NotFoundError(f"Browser item not found for URI: {uri}")
+            if not bool(getattr(item, "is_loadable", False)):
+                raise InvalidParamsError(f"Browser item is not loadable: {uri}")
+
+            before_devices = list(track.devices)
+            self._song.view.selected_track = track
+            browser.load_item(item)
+            after_devices = list(track.devices)
+            try:
+                loaded_device = self._infer_loaded_device(before_devices, after_devices)
+            except RuntimeError as exc:
+                raise RuntimeError(f"{exc} on track {track_index}") from exc
+            return {
+                "track_index": track_index,
+                "device_index": after_devices.index(loaded_device) + 1,
+                "name": str(getattr(loaded_device, "name", "")),
+                "uri": uri,
+            }
+
+        return self._run_on_main_thread(_load)
+
+    def handle_load_effect(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Load an effect onto a track from the audio/midi effect Browser roots."""
+        track_index = self._require_track_index(params)
+        uri = self._require_non_empty_string(params.get("uri"), "uri")
+        position = params.get("position", -1)
+        if isinstance(position, bool) or not isinstance(position, int):
+            raise InvalidParamsError("'position' must be an integer")
+        if position != -1:
+            raise InvalidParamsError(
+                "Arbitrary effect insertion is unsupported on the Live 12.2.5 "
+                "runtime; use position=-1"
+            )
+
+        def _load() -> dict[str, Any]:
+            browser = self._browser()
+            track = self._resolve_track(track_index)
+            item = self._find_item_in_roots(
+                [browser.audio_effects, browser.midi_effects],
+                uri,
+            )
+            if item is None:
+                raise NotFoundError(f"Browser item not found for URI: {uri}")
+            if not bool(getattr(item, "is_loadable", False)):
+                raise InvalidParamsError(f"Browser item is not loadable: {uri}")
+
+            before_devices = list(track.devices)
+            self._song.view.selected_track = track
+            browser.load_item(item)
+            after_devices = list(track.devices)
+            try:
+                loaded_device = self._infer_loaded_device(before_devices, after_devices)
+            except RuntimeError as exc:
+                raise RuntimeError(f"{exc} on track {track_index}") from exc
+            return {
+                "track_index": track_index,
+                "device_index": after_devices.index(loaded_device) + 1,
+                "name": str(getattr(loaded_device, "name", "")),
+                "uri": uri,
+            }
+
+        return self._run_on_main_thread(_load)
 
 
 __all__ = ["BrowserHandler"]

--- a/remote_script/AbletonLiveMCP/handlers/device.py
+++ b/remote_script/AbletonLiveMCP/handlers/device.py
@@ -1,0 +1,141 @@
+"""Device and parameter command handlers for the Ableton Live Remote Script."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class DeviceHandler(BaseHandler):
+    """Handle device parameter inspection and writes."""
+
+    def _require_index(self, params: dict[str, Any], name: str) -> int:
+        """Return a validated 1-based index parameter."""
+        raw_value = params.get(name)
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            raise InvalidParamsError(f"'{name}' must be an integer")
+        if raw_value < 1:
+            raise InvalidParamsError(f"'{name}' must be at least 1")
+        return raw_value
+
+    def _require_numeric_value(self, params: dict[str, Any], name: str) -> float:
+        """Return a validated numeric parameter value."""
+        raw_value = params.get(name)
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+            raise InvalidParamsError(f"'{name}' must be a number")
+        return float(raw_value)
+
+    def _resolve_track(self, track_index: int) -> Any:
+        """Resolve a 1-based track index to a track object."""
+        tracks = self._song.tracks
+        track_count = len(tracks)
+        if track_index > track_count:
+            raise NotFoundError(
+                f"Track {track_index} does not exist (song has {track_count} track(s))"
+            )
+        return tracks[track_index - 1]
+
+    def _resolve_device(self, track: Any, track_index: int, device_index: int) -> Any:
+        """Resolve a 1-based device index on a track."""
+        devices = list(track.devices)
+        device_count = len(devices)
+        if device_index > device_count:
+            raise NotFoundError(
+                f"Device {device_index} does not exist on track {track_index} "
+                f"(track has {device_count} device(s))"
+            )
+        return devices[device_index - 1]
+
+    def _resolve_parameter(
+        self,
+        device: Any,
+        track_index: int,
+        device_index: int,
+        parameter_index: int,
+    ) -> Any:
+        """Resolve a 1-based parameter index on a device."""
+        parameters = list(device.parameters)
+        parameter_count = len(parameters)
+        if parameter_index > parameter_count:
+            raise NotFoundError(
+                f"Parameter {parameter_index} does not exist on device {device_index} "
+                f"of track {track_index} (device has {parameter_count} parameter(s))"
+            )
+        return parameters[parameter_index - 1]
+
+    def _serialize_parameter(
+        self,
+        parameter: Any,
+        parameter_index: int,
+    ) -> dict[str, Any]:
+        """Serialize a DeviceParameter into the response payload."""
+        return {
+            "parameter_index": parameter_index,
+            "name": str(getattr(parameter, "name", "")),
+            "value": float(parameter.value),
+            "min": float(parameter.min),
+            "max": float(parameter.max),
+            "is_quantized": bool(parameter.is_quantized),
+        }
+
+    def handle_get_parameters(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return all parameters for one device on one track."""
+        track_index = self._require_index(params, "track_index")
+        device_index = self._require_index(params, "device_index")
+
+        def _read() -> dict[str, Any]:
+            track = self._resolve_track(track_index)
+            device = self._resolve_device(track, track_index, device_index)
+            parameters = list(device.parameters)
+            return {
+                "track_index": track_index,
+                "device_index": device_index,
+                "device_name": str(getattr(device, "name", "")),
+                "parameters": [
+                    self._serialize_parameter(parameter, parameter_index + 1)
+                    for parameter_index, parameter in enumerate(parameters)
+                ],
+            }
+
+        return self._run_on_main_thread(_read)
+
+    def handle_set_parameter(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set one parameter using Live's actual parameter range."""
+        track_index = self._require_index(params, "track_index")
+        device_index = self._require_index(params, "device_index")
+        parameter_index = self._require_index(params, "parameter_index")
+        value = self._require_numeric_value(params, "value")
+
+        def _write() -> dict[str, Any]:
+            track = self._resolve_track(track_index)
+            device = self._resolve_device(track, track_index, device_index)
+            parameter = self._resolve_parameter(
+                device,
+                track_index,
+                device_index,
+                parameter_index,
+            )
+            minimum = float(parameter.min)
+            maximum = float(parameter.max)
+            if value < minimum or value > maximum:
+                raise InvalidParamsError(
+                    f"'value' must be between {minimum} and {maximum}, got {value}"
+                )
+            parameter.value = value
+            return {
+                "track_index": track_index,
+                "device_index": device_index,
+                "parameter_index": parameter_index,
+                "value": float(parameter.value),
+            }
+
+        return self._run_on_main_thread(_write)
+
+
+__all__ = ["DeviceHandler"]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -2,6 +2,7 @@
 
 import mcp_ableton.tools.browser  # noqa: F401
 import mcp_ableton.tools.clip  # noqa: F401
+import mcp_ableton.tools.device  # noqa: F401
 import mcp_ableton.tools.session  # noqa: F401
 import mcp_ableton.tools.track  # noqa: F401
 

--- a/src/mcp_ableton/tools/device.py
+++ b/src/mcp_ableton/tools/device.py
@@ -1,0 +1,209 @@
+"""MCP tools for Ableton Live devices, parameters, and Browser-based loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+class DeviceParameterInfo(BaseModel):
+    """One device parameter using Live's native value range."""
+
+    parameter_index: int
+    name: str
+    value: float
+    min: float
+    max: float
+    is_quantized: bool
+
+
+class DeviceParametersResult(BaseModel):
+    """Parameters for one device on one track."""
+
+    track_index: int
+    device_index: int
+    device_name: str
+    parameters: list[DeviceParameterInfo]
+
+
+class ParameterSetResult(BaseModel):
+    """Result of writing a parameter using its actual Live value."""
+
+    track_index: int
+    device_index: int
+    parameter_index: int
+    value: float
+
+
+class InstrumentLoadedResult(BaseModel):
+    """Result of loading an instrument onto a track."""
+
+    track_index: int
+    device_index: int
+    name: str
+    uri: str
+
+
+class EffectLoadedResult(BaseModel):
+    """Result of loading an effect onto a track."""
+
+    track_index: int
+    device_index: int
+    name: str
+    uri: str
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    """Extract the Ableton TCP connection from the FastMCP context."""
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def get_device_parameters(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    device_index: Annotated[
+        int,
+        Field(description="1-based device index on the track.", ge=1),
+    ],
+) -> DeviceParametersResult:
+    """Get all parameters for a device using Live's actual parameter values."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="device.get_parameters",
+        params={
+            "track_index": track_index,
+            "device_index": device_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return DeviceParametersResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_device_parameter(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    device_index: Annotated[
+        int,
+        Field(description="1-based device index on the track.", ge=1),
+    ],
+    parameter_index: Annotated[
+        int,
+        Field(description="1-based parameter index on the device.", ge=1),
+    ],
+    value: Annotated[
+        float,
+        Field(
+            description=(
+                "Parameter value in the device parameter's real Live range, "
+                "not a normalized 0-1 value."
+            ),
+        ),
+    ],
+) -> ParameterSetResult:
+    """Set a device parameter using its native Live min/max range."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="device.set_parameter",
+        params={
+            "track_index": track_index,
+            "device_index": device_index,
+            "parameter_index": parameter_index,
+            "value": value,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ParameterSetResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def load_instrument(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    uri: Annotated[
+        str,
+        Field(description="Browser item URI for an instrument.", min_length=1),
+    ],
+) -> InstrumentLoadedResult:
+    """Load an instrument Browser item onto a MIDI track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="browser.load_instrument",
+        params={"track_index": track_index, "uri": uri},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return InstrumentLoadedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def load_effect(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(description="1-based track index.", ge=1),
+    ],
+    uri: Annotated[
+        str,
+        Field(
+            description="Browser item URI for an audio or MIDI effect.",
+            min_length=1,
+        ),
+    ],
+    position: Annotated[
+        int,
+        Field(
+            description=(
+                "Requested insertion point. Live 12.2.5 only supports -1 here, "
+                "which appends via the Browser load path."
+            ),
+        ),
+    ] = -1,
+) -> EffectLoadedResult:
+    """Load an effect Browser item onto a track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="browser.load_effect",
+        params={
+            "track_index": track_index,
+            "uri": uri,
+            "position": position,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return EffectLoadedResult.model_validate(response.result)
+
+
+__all__ = [
+    "DeviceParameterInfo",
+    "DeviceParametersResult",
+    "EffectLoadedResult",
+    "InstrumentLoadedResult",
+    "ParameterSetResult",
+    "get_device_parameters",
+    "load_effect",
+    "load_instrument",
+    "set_device_parameter",
+]


### PR DESCRIPTION
## Summary

- Add typed MCP device and parameter tools for reading parameters, setting native Live values, and loading instruments/effects.
- Add Remote Script support for `device.*` commands and browser-backed device loading on Live 12.2.5.
- Cover the new tool surface with tool tests, handler tests, and a TCP round-trip integration case.

## MCP tools

- Add `get_device_parameters(track_index, device_index)`.
- Add `set_device_parameter(track_index, device_index, parameter_index, value)` using the parameter's real Live min/max range.
- Add `load_instrument(track_index, uri)`.
- Add `load_effect(track_index, uri, position=-1)`.
- Wire `src/mcp_ableton/tools/device.py` through `src/mcp_ableton/tools/__init__.py`.

## Remote Script

- Add `remote_script/AbletonLiveMCP/handlers/device.py` for `device.get_parameters` and `device.set_parameter`.
- Register the `device` handler category in `remote_script/AbletonLiveMCP/__init__.py`.
- Extend `remote_script/AbletonLiveMCP/handlers/browser.py` with `browser.load_instrument` and `browser.load_effect`.
- Restrict instrument lookup to the Browser instruments root and effect lookup to the audio/midi effect roots.
- Reject `load_effect(position != -1)` on Live 12.2.5 with `INVALID_PARAMS`.
- Diff loaded devices by before/after sequence rather than Python object identity, based on Live 12.2.5 smoke behavior.

## Tests

- Add `Tests/tools/test_device.py`.
- Add `Tests/test_device_handler.py`.
- Extend `Tests/test_integration.py` with a device payload round-trip.
- Validation run:
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest`

## Manual verification

- Verified on March 29, 2026 against Ableton Live 12.2.5 using the real stdio MCP server path from the working tree.
- `get_session_info` returned tempo `120.0`, signature `4/4`, `track_count=4`, `is_playing=false`, `is_recording=false`.
- `search_browser` found instrument URI `query:Synths#Analog`; `create_midi_track` created disposable track `5` named `Issue12 Smoke MIDI`.
- `load_instrument` loaded `Analog` onto track `5` at device index `1`.
- `get_device_parameters` returned `172` parameters for `Analog`; smoke update used `PB Range` parameter `3`.
- `set_device_parameter` changed `PB Range` from `0.1666666716337204` to `0.17666667699813843`.
- `search_browser` found effect URI `query:AudioFx#Auto%20Filter`; `load_effect(..., position=-1)` loaded `Auto Filter` onto track `5` at device index `2`.
- Final track device chain was `["Analog", "Auto Filter"]`.
- `load_effect(..., position=0)` returned `INVALID_PARAMS` with message `Arbitrary effect insertion is unsupported on the Live 12.2.5 runtime; use position=-1`.
- Checked appended Ableton `Log.txt` lines after the smoke run; no `Traceback` or unexpected `ERROR` lines were present.

## Docs

- Update the README status line to mention device/parameter MCP tools.
- Add the `load_effect -> browser.load_effect` mapping to ADR-002.

Closes #12
