### PR TITLE
Add basic mixer MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport**, **track management**, **session clip**, **MIDI note**, **browser**, and **device/parameter** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — This project is in early development. The MCP server and Remote Script can talk over TCP; **session/transport**, **track management**, **session clip**, **MIDI note**, **browser**, **device/parameter**, and **basic mixer** MCP tools are implemented, with more domains coming. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -163,7 +163,7 @@ For more detailed instructions, see [docs/installation.md](docs/installation.md)
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. What's next is implementing the actual tools — track creation, clip manipulation, device control, mixing, and more.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. Phase 1 now includes transport/session, track management, session clips, MIDI notes, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as arrangement, scenes, and extended mixing.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -85,6 +85,15 @@ class _DeviceHandler:
         }
 
 
+class _MixerHandler:
+    def handle_get_master_info(self, params):
+        return {
+            "name": "Master",
+            "volume": 0.88,
+            "pan": 0.0,
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
@@ -93,6 +102,7 @@ def tcp_server():
     dispatcher.register("session", _EchoHandler())
     dispatcher.register("browser", _BrowserHandler())
     dispatcher.register("device", _DeviceHandler())
+    dispatcher.register("mixer", _MixerHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -194,5 +204,24 @@ class TestFullRoundTrip:
         assert resp.result["device_name"] == "Analog"
         assert resp.result["parameters"][0]["parameter_index"] == 1
         assert resp.result["parameters"][1]["name"] == "Filter Freq"
+
+        await conn.disconnect()
+
+    async def test_mixer_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="mixer.get_master_info", id="mixer-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "mixer-1"
+        assert resp.result is not None
+        assert resp.result == {
+            "name": "Master",
+            "volume": 0.88,
+            "pan": 0.0,
+        }
 
         await conn.disconnect()

--- a/Tests/test_mixer_handler.py
+++ b/Tests/test_mixer_handler.py
@@ -1,0 +1,126 @@
+"""Tests for the Remote Script MixerHandler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from AbletonLiveMCP.dispatcher import Dispatcher, InvalidParamsError
+from AbletonLiveMCP.handlers.mixer import MixerHandler
+
+
+class _MixerDevice:
+    def __init__(self, volume: float = 0.8, pan: float = 0.1) -> None:
+        self.volume = MagicMock(value=volume)
+        self.panning = MagicMock(value=pan)
+
+
+class _Track:
+    def __init__(self, name: str, *, volume: float = 0.8, pan: float = 0.1) -> None:
+        self.name = name
+        self.mixer_device = _MixerDevice(volume=volume, pan=pan)
+
+
+class _Song:
+    def __init__(self) -> None:
+        self.tracks = [
+            _Track("Track 1", volume=0.82, pan=0.15),
+            _Track("Track 2", volume=0.63, pan=-0.35),
+        ]
+        self.master_track = _Track("Master", volume=0.9, pan=0.0)
+
+
+class _FakeControlSurface:
+    def __init__(self, song: _Song | None = None) -> None:
+        self._song = song or _Song()
+
+    def song(self) -> _Song:
+        return self._song
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay: int, callback) -> None:
+        callback()
+
+
+@pytest.fixture
+def song() -> _Song:
+    return _Song()
+
+
+@pytest.fixture
+def handler(song: _Song) -> MixerHandler:
+    return MixerHandler(_FakeControlSurface(song))
+
+
+class TestSetTrackVolume:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_track_volume({"track_index": 2, "volume": 0.45})
+
+        assert result == {"track_index": 2, "volume": 0.45}
+        assert song.tracks[1].mixer_device.volume.value == 0.45
+
+    def test_missing_track_returns_not_found(self, handler: MixerHandler) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface())
+        dispatcher.register("mixer", handler)
+
+        response = dispatcher.dispatch(
+            "mixer.set_track_volume",
+            {"track_index": 99, "volume": 0.5},
+            "mix-1",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+        assert "Track 99" in response["error"]["message"]
+
+    def test_out_of_range_volume(self, handler: MixerHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="volume"):
+            handler.handle_set_track_volume({"track_index": 1, "volume": 1.1})
+
+
+class TestSetTrackPan:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_track_pan({"track_index": 1, "pan": -0.5})
+
+        assert result == {"track_index": 1, "pan": -0.5}
+        assert song.tracks[0].mixer_device.panning.value == -0.5
+
+    def test_out_of_range_pan(self, handler: MixerHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="pan"):
+            handler.handle_set_track_pan({"track_index": 1, "pan": -1.5})
+
+
+class TestGetMasterInfo:
+    def test_serialization_shape(self, handler: MixerHandler) -> None:
+        result = handler.handle_get_master_info({})
+
+        assert result == {
+            "name": "Master",
+            "volume": 0.9,
+            "pan": 0.0,
+        }
+
+
+class TestSetMasterVolume:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_master_volume({"volume": 0.72})
+
+        assert result == {"volume": 0.72}
+        assert song.master_track.mixer_device.volume.value == 0.72
+
+
+class TestDispatcherRegistration:
+    def test_dispatcher_routes_mixer_commands(self, song: _Song) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface(song))
+        dispatcher.register("mixer", MixerHandler(_FakeControlSurface(song)))
+
+        response = dispatcher.dispatch("mixer.get_master_info", {}, "mix-2")
+
+        assert response["status"] == "ok"
+        assert response["result"] == {
+            "name": "Master",
+            "volume": 0.9,
+            "pan": 0.0,
+        }

--- a/Tests/tools/test_mixer.py
+++ b/Tests/tools/test_mixer.py
@@ -1,0 +1,268 @@
+"""Tests for mixer MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.mixer import (
+    MasterTrackInfo,
+    MasterVolumeSetResult,
+    TrackPanSetResult,
+    TrackVolumeSetResult,
+    get_master_info,
+    set_master_volume,
+    set_track_pan,
+    set_track_volume,
+)
+
+TOOL_NAMES = [
+    "set_track_volume",
+    "set_track_pan",
+    "get_master_info",
+    "set_master_volume",
+]
+
+MASTER_INFO_RESULT = {
+    "name": "Master",
+    "volume": 0.74,
+    "pan": 0.0,
+}
+
+TRACK_VOLUME_RESULT = {
+    "track_index": 2,
+    "volume": 0.5,
+}
+
+TRACK_PAN_RESULT = {
+    "track_index": 2,
+    "pan": -0.25,
+}
+
+MASTER_VOLUME_RESULT = {
+    "volume": 0.8,
+}
+
+
+def _ok_response(result: dict, request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_set_track_volume_schema(self) -> None:
+        tool = self._get_tool("set_track_volume")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["volume"]["minimum"] == 0.0
+        assert props["volume"]["maximum"] == 1.0
+
+    def test_set_track_pan_schema(self) -> None:
+        tool = self._get_tool("set_track_pan")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["pan"]["minimum"] == -1.0
+        assert props["pan"]["maximum"] == 1.0
+
+    def test_set_master_volume_schema(self) -> None:
+        tool = self._get_tool("set_master_volume")
+        props = tool.parameters["properties"]
+        assert props["volume"]["minimum"] == 0.0
+        assert props["volume"]["maximum"] == 1.0
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    def test_set_track_volume_rejects_non_positive_track_index(self) -> None:
+        model = self._arg_model("set_track_volume")
+        with pytest.raises(ValidationError):
+            model(track_index=0, volume=0.5)
+
+    @pytest.mark.parametrize("volume", [-0.1, 1.1])
+    def test_set_track_volume_rejects_out_of_range_volume(self, volume: float) -> None:
+        model = self._arg_model("set_track_volume")
+        with pytest.raises(ValidationError):
+            model(track_index=1, volume=volume)
+
+    @pytest.mark.parametrize("pan", [-1.1, 1.1])
+    def test_set_track_pan_rejects_out_of_range_pan(self, pan: float) -> None:
+        model = self._arg_model("set_track_pan")
+        with pytest.raises(ValidationError):
+            model(track_index=1, pan=pan)
+
+    def test_set_master_volume_accepts_upper_bound(self) -> None:
+        model = self._arg_model("set_master_volume")
+        args = model(volume=1.0)
+        assert args.volume == 1.0
+
+
+class TestSetTrackVolume:
+    async def test_returns_track_volume_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_VOLUME_RESULT)
+
+        result = await set_track_volume(ctx=mock_context, track_index=2, volume=0.5)
+
+        assert isinstance(result, TrackVolumeSetResult)
+        assert result.track_index == 2
+        assert result.volume == 0.5
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_VOLUME_RESULT)
+
+        await set_track_volume(ctx=mock_context, track_index=3, volume=0.25)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_track_volume"
+        assert req.params == {"track_index": 3, "volume": 0.25}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Track 9 does not exist",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await set_track_volume(ctx=mock_context, track_index=9, volume=0.4)
+
+
+class TestSetTrackPan:
+    async def test_returns_track_pan_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_PAN_RESULT)
+
+        result = await set_track_pan(ctx=mock_context, track_index=2, pan=-0.25)
+
+        assert isinstance(result, TrackPanSetResult)
+        assert result.track_index == 2
+        assert result.pan == -0.25
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(TRACK_PAN_RESULT)
+
+        await set_track_pan(ctx=mock_context, track_index=1, pan=0.75)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_track_pan"
+        assert req.params == {"track_index": 1, "pan": 0.75}
+
+
+class TestGetMasterInfo:
+    async def test_returns_master_info(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(MASTER_INFO_RESULT)
+
+        result = await get_master_info(ctx=mock_context)
+
+        assert isinstance(result, MasterTrackInfo)
+        assert result.name == "Master"
+        assert result.volume == 0.74
+        assert result.pan == 0.0
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(MASTER_INFO_RESULT)
+
+        await get_master_info(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.get_master_info"
+        assert req.params == {}
+
+
+class TestSetMasterVolume:
+    async def test_returns_master_volume_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(MASTER_VOLUME_RESULT)
+
+        result = await set_master_volume(ctx=mock_context, volume=0.8)
+
+        assert isinstance(result, MasterVolumeSetResult)
+        assert result.volume == 0.8
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(MASTER_VOLUME_RESULT)
+
+        await set_master_volume(ctx=mock_context, volume=0.35)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_master_volume"
+        assert req.params == {"volume": 0.35}
+
+    async def test_raises_on_invalid_params(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message="'volume' must be between 0.0 and 1.0, got 1.5",
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await set_master_volume(ctx=mock_context, volume=0.9)

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -501,6 +501,10 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `get_browser_tree` | `browser.get_tree` |
 | `get_browser_items` | `browser.get_items` |
 | `search_browser` | `browser.search` |
+| `set_track_volume` | `mixer.set_track_volume` |
+| `set_track_pan` | `mixer.set_track_pan` |
+| `get_master_info` | `mixer.get_master_info` |
+| `set_master_volume` | `mixer.set_master_volume` |
 
 ### Threading model (same as competitors, proven pattern)
 

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -53,6 +53,7 @@ class AbletonLiveMCP(ControlSurface):
         from .handlers.browser import BrowserHandler
         from .handlers.clip import ClipHandler
         from .handlers.device import DeviceHandler
+        from .handlers.mixer import MixerHandler
         from .handlers.session import SessionHandler
         from .handlers.track import TrackHandler
 
@@ -61,6 +62,7 @@ class AbletonLiveMCP(ControlSurface):
         self._dispatcher.register("device", DeviceHandler(self))
         self._dispatcher.register("clip", ClipHandler(self))
         self._dispatcher.register("browser", BrowserHandler(self))
+        self._dispatcher.register("mixer", MixerHandler(self))
 
     def disconnect(self) -> None:
         """Ableton lifecycle hook -- shut down the TCP server."""

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -7,6 +7,7 @@ issues as the tool surface grows.
 from .browser import BrowserHandler
 from .clip import ClipHandler
 from .device import DeviceHandler
+from .mixer import MixerHandler
 from .session import SessionHandler
 from .track import TrackHandler
 
@@ -14,6 +15,7 @@ __all__ = [
     "BrowserHandler",
     "ClipHandler",
     "DeviceHandler",
+    "MixerHandler",
     "SessionHandler",
     "TrackHandler",
 ]

--- a/remote_script/AbletonLiveMCP/handlers/mixer.py
+++ b/remote_script/AbletonLiveMCP/handlers/mixer.py
@@ -1,0 +1,128 @@
+"""Mixer command handlers for the Ableton Live MCP Remote Script."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class MixerHandler(BaseHandler):
+    """Handle per-track and master mixer commands."""
+
+    def _require_track_index(self, params: dict[str, Any]) -> int:
+        """Return a validated 1-based track index."""
+        track_index = params.get("track_index")
+        if track_index is None:
+            raise InvalidParamsError("'track_index' parameter is required")
+        if isinstance(track_index, bool) or not isinstance(track_index, int):
+            raise InvalidParamsError("'track_index' must be an integer")
+        if track_index < 1:
+            raise InvalidParamsError("'track_index' must be at least 1")
+        return track_index
+
+    def _require_float_range(
+        self,
+        params: dict[str, Any],
+        name: str,
+        *,
+        minimum: float,
+        maximum: float,
+    ) -> float:
+        """Return a validated numeric parameter within a closed range."""
+        raw_value = params.get(name)
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+            raise InvalidParamsError(f"'{name}' must be a number")
+
+        value = float(raw_value)
+        if value < minimum or value > maximum:
+            raise InvalidParamsError(
+                f"'{name}' must be between {minimum} and {maximum}, got {value}"
+            )
+        return value
+
+    def _resolve_track(self, track_index: int) -> Any:
+        """Resolve a 1-based track index to a normal track."""
+        tracks = self._song.tracks
+        track_count = len(tracks)
+        if track_index > track_count:
+            raise NotFoundError(
+                f"Track {track_index} does not exist (song has {track_count} track(s))"
+            )
+        return tracks[track_index - 1]
+
+    def handle_set_track_volume(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set a normal track's volume."""
+        track_index = self._require_track_index(params)
+        volume = self._require_float_range(
+            params,
+            "volume",
+            minimum=0.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            track = self._resolve_track(track_index)
+            track.mixer_device.volume.value = volume
+            return {
+                "track_index": track_index,
+                "volume": float(track.mixer_device.volume.value),
+            }
+
+        return self._run_on_main_thread(_write)
+
+    def handle_set_track_pan(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set a normal track's pan."""
+        track_index = self._require_track_index(params)
+        pan = self._require_float_range(
+            params,
+            "pan",
+            minimum=-1.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            track = self._resolve_track(track_index)
+            track.mixer_device.panning.value = pan
+            return {
+                "track_index": track_index,
+                "pan": float(track.mixer_device.panning.value),
+            }
+
+        return self._run_on_main_thread(_write)
+
+    def handle_get_master_info(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return the master track name and mixer state."""
+
+        def _read() -> dict[str, Any]:
+            master_track = self._song.master_track
+            mixer = master_track.mixer_device
+            return {
+                "name": str(getattr(master_track, "name", "")),
+                "volume": float(mixer.volume.value),
+                "pan": float(mixer.panning.value),
+            }
+
+        return self._run_on_main_thread(_read)
+
+    def handle_set_master_volume(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set the master track volume."""
+        volume = self._require_float_range(
+            params,
+            "volume",
+            minimum=0.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            mixer = self._song.master_track.mixer_device
+            mixer.volume.value = volume
+            return {"volume": float(mixer.volume.value)}
+
+        return self._run_on_main_thread(_write)
+
+
+__all__ = ["MixerHandler"]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -3,6 +3,7 @@
 import mcp_ableton.tools.browser  # noqa: F401
 import mcp_ableton.tools.clip  # noqa: F401
 import mcp_ableton.tools.device  # noqa: F401
+import mcp_ableton.tools.mixer  # noqa: F401
 import mcp_ableton.tools.session  # noqa: F401
 import mcp_ableton.tools.track  # noqa: F401
 

--- a/src/mcp_ableton/tools/mixer.py
+++ b/src/mcp_ableton/tools/mixer.py
@@ -1,0 +1,153 @@
+"""MCP tools for Ableton Live mixer control."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+class MasterTrackInfo(BaseModel):
+    """Snapshot of the master track mixer state."""
+
+    name: str
+    volume: float
+    pan: float
+
+
+class TrackVolumeSetResult(BaseModel):
+    """Result of ``set_track_volume``."""
+
+    track_index: int
+    volume: float
+
+
+class TrackPanSetResult(BaseModel):
+    """Result of ``set_track_pan``."""
+
+    track_index: int
+    pan: float
+
+
+class MasterVolumeSetResult(BaseModel):
+    """Result of ``set_master_volume``."""
+
+    volume: float
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    """Extract the Ableton TCP connection from the FastMCP context."""
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def set_track_volume(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(
+            description="1-based track index.",
+            ge=1,
+        ),
+    ],
+    volume: Annotated[
+        float,
+        Field(
+            description="Track volume value normalized to 0.0-1.0.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ],
+) -> TrackVolumeSetResult:
+    """Set a track's volume."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_track_volume",
+        params={"track_index": track_index, "volume": volume},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackVolumeSetResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_track_pan(
+    ctx: Context,
+    track_index: Annotated[
+        int,
+        Field(
+            description="1-based track index.",
+            ge=1,
+        ),
+    ],
+    pan: Annotated[
+        float,
+        Field(
+            description="Track pan from -1.0 (left) to 1.0 (right).",
+            ge=-1.0,
+            le=1.0,
+        ),
+    ],
+) -> TrackPanSetResult:
+    """Set a track's pan."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_track_pan",
+        params={"track_index": track_index, "pan": pan},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return TrackPanSetResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_master_info(ctx: Context) -> MasterTrackInfo:
+    """Get the master track mixer state."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(command="mixer.get_master_info")
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return MasterTrackInfo.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_master_volume(
+    ctx: Context,
+    volume: Annotated[
+        float,
+        Field(
+            description="Master volume value normalized to 0.0-1.0.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ],
+) -> MasterVolumeSetResult:
+    """Set the master track volume."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_master_volume",
+        params={"volume": volume},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return MasterVolumeSetResult.model_validate(response.result)
+
+
+__all__ = [
+    "MasterTrackInfo",
+    "MasterVolumeSetResult",
+    "TrackPanSetResult",
+    "TrackVolumeSetResult",
+    "get_master_info",
+    "set_master_volume",
+    "set_track_pan",
+    "set_track_volume",
+]


### PR DESCRIPTION
## Summary
- add a dedicated `src/mcp_ableton/tools/mixer.py` module with typed MCP tools for track volume, track pan, master info, and master volume
- add matching `mixer.*` Remote Script handlers and register the new category in the dispatcher startup path
- update README status text and ADR-002 command mapping entries for the new mixer commands

## MCP tools
- `set_track_volume(track_index, volume)` with 1-based track validation and `0.0..1.0` volume bounds
- `set_track_pan(track_index, pan)` with 1-based track validation and `-1.0..1.0` pan bounds
- `get_master_info()` returning `{name, volume, pan}`
- `set_master_volume(volume)` with `0.0..1.0` volume bounds

## Remote Script
- add `remote_script/AbletonLiveMCP/handlers/mixer.py`
- route all mixer reads and writes through `_run_on_main_thread`
- validate bad/missing params as `INVALID_PARAMS`, missing tracks as `NOT_FOUND`, and write normalized mixer values through Live's `mixer_device`

## Tests
- add `Tests/tools/test_mixer.py`
- add `Tests/test_mixer_handler.py`
- extend `Tests/test_integration.py` with a round-trip mixer payload case
- full local gate passed:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification
- smoke path used the real stdio MCP server via `uv run mcp-ableton` against Ableton Live 12.2.5 with the symlinked `AbletonLiveMCP` Remote Script listening on port 9877
- `get_session_info` succeeded with tempo `120.0`, signature `4/4`, track count `4`, and song length `232.0`
- created disposable MIDI track `Smoke Mixer Temp` at track `5`
- `set_track_volume(track_index=5, volume=0.25)` succeeded and `get_track_info(5)` read back volume `0.25`
- `set_track_pan(track_index=5, pan=-0.5)` succeeded and `get_track_info(5)` read back pan `-0.5`
- `get_master_info()` returned `{name: "Main", volume: 0.8500000238418579, pan: 0.0}`
- `set_master_volume(volume=0.78)` succeeded and `get_master_info()` read back `0.7799999713897705`; restored master volume to `0.8500000238418579` before exit
- deleted the disposable track after verification
- checked new lines in `/Users/markfeaver/Library/Preferences/Ableton/Live 12.2.5/Log.txt`; no fresh `Traceback`, `Exception`, or error lines were emitted during the successful smoke run

## Docs
- update the README implementation status line and current-status paragraph
- add the four mixer command mappings to ADR-002

Closes #27
