### PR TITLE
Add arrangement MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current Phase 1 tool surface: **session/transport**, **track management**, **session clip**, **MIDI note**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport**, **track management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. Phase 1 now includes transport/session, track management, session clips, MIDI notes, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as arrangement, scenes, and extended mixing.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session, track management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as scenes and extended mixing.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/test_arrangement_handler.py
+++ b/Tests/test_arrangement_handler.py
@@ -1,0 +1,401 @@
+"""Tests for the Remote Script ArrangementHandler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from AbletonLiveMCP.dispatcher import Dispatcher, InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.arrangement import ArrangementHandler
+
+
+class _Mixer:
+    def __init__(self, volume: float = 0.8, pan: float = 0.1) -> None:
+        self.volume = MagicMock(value=volume)
+        self.panning = MagicMock(value=pan)
+
+
+class _Slot:
+    def __init__(self, has_clip: bool = False) -> None:
+        self.has_clip = has_clip
+
+
+class _Device:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _Track:
+    def __init__(
+        self,
+        name: str,
+        *,
+        midi: bool = True,
+        audio: bool = False,
+        can_be_armed: bool = True,
+    ) -> None:
+        self.name = name
+        self.has_audio_input = audio
+        self.has_midi_input = midi
+        self.mute = False
+        self.solo = False
+        self.arm = False
+        self.can_be_armed = can_be_armed
+        self.mixer_device = _Mixer()
+        self.devices = [_Device("Device A")]
+        self.clip_slots = [_Slot(False), _Slot(True)]
+
+
+class _FakeControlSurface:
+    def __init__(self, song: object) -> None:
+        self._song = song
+
+    def song(self):
+        return self._song
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def show_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay, callback):
+        callback()
+
+
+class _ArrangementClip:
+    def __init__(
+        self,
+        name: str,
+        start_time: float,
+        length: float,
+        *,
+        audio: bool = False,
+    ) -> None:
+        self.name = name
+        self.start_time = start_time
+        self.length = length
+        self.end_time = start_time + length
+        self.is_audio_clip = audio
+        self.is_midi_clip = not audio
+
+
+class _ArrangementTrack(_Track):
+    def __init__(
+        self,
+        name: str,
+        *,
+        midi: bool = True,
+        audio: bool = False,
+        arrangement_clips: list[_ArrangementClip] | None = None,
+    ) -> None:
+        super().__init__(name, midi=midi, audio=audio)
+        self.arrangement_clips = list(arrangement_clips or [])
+        self._sort_arrangement_clips()
+
+    def _sort_arrangement_clips(self) -> None:
+        self.arrangement_clips.sort(
+            key=lambda clip: (clip.start_time, clip.end_time, clip.name)
+        )
+
+    def create_midi_clip(self, start_time: float, length: float) -> None:
+        if not self.has_midi_input:
+            raise RuntimeError("track does not accept MIDI clips")
+        self.arrangement_clips.append(
+            _ArrangementClip("New MIDI Clip", start_time, length, audio=False)
+        )
+        self._sort_arrangement_clips()
+
+    def duplicate_clip_to_arrangement(
+        self,
+        clip: _ArrangementClip,
+        destination_time: float,
+    ) -> None:
+        if clip.is_midi_clip and not self.has_midi_input:
+            raise RuntimeError("target track does not accept MIDI clips")
+        if clip.is_audio_clip and not self.has_audio_input:
+            raise RuntimeError("target track does not accept audio clips")
+
+        self.arrangement_clips.append(
+            _ArrangementClip(
+                f"{clip.name} Copy",
+                destination_time,
+                clip.length,
+                audio=clip.is_audio_clip,
+            )
+        )
+        self._sort_arrangement_clips()
+
+    def delete_clip(self, clip: _ArrangementClip) -> None:
+        self.arrangement_clips.remove(clip)
+
+
+class _ArrangementSong:
+    def __init__(self) -> None:
+        self.song_length = 96.0
+        self.loop = False
+        self.loop_start = 0.0
+        self.loop_length = 4.0
+        self.tracks = [
+            _ArrangementTrack(
+                "MIDI 1",
+                midi=True,
+                arrangement_clips=[
+                    _ArrangementClip("Verse", 0.0, 8.0),
+                    _ArrangementClip("Hook", 16.0, 4.0),
+                ],
+            ),
+            _ArrangementTrack(
+                "Audio 1",
+                midi=False,
+                audio=True,
+                arrangement_clips=[
+                    _ArrangementClip("Vocal", 4.0, 8.0, audio=True),
+                ],
+            ),
+            _ArrangementTrack("MIDI 2", midi=True, arrangement_clips=[]),
+        ]
+
+
+class _LaggyLoopSong(_ArrangementSong):
+    def __init__(self) -> None:
+        self._loop_current = False
+        self._loop_visible = False
+        super().__init__()
+
+    @property
+    def loop(self) -> bool:
+        visible = self._loop_visible
+        self._loop_visible = self._loop_current
+        return visible
+
+    @loop.setter
+    def loop(self, value: bool) -> None:
+        self._loop_current = bool(value)
+
+
+@pytest.fixture
+def arrangement_song() -> _ArrangementSong:
+    return _ArrangementSong()
+
+
+@pytest.fixture
+def arrangement_handler(arrangement_song: _ArrangementSong) -> ArrangementHandler:
+    return ArrangementHandler(_FakeControlSurface(arrangement_song))
+
+
+class TestGetArrangementClips:
+    def test_single_track(self, arrangement_handler: ArrangementHandler) -> None:
+        result = arrangement_handler.handle_get_clips({"track_index": 1})
+
+        assert result["track_index"] == 1
+        assert len(result["clips"]) == 2
+        assert result["clips"][0]["track_index"] == 1
+        assert result["clips"][0]["clip_index"] == 1
+
+    def test_all_tracks_when_track_omitted(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        result = arrangement_handler.handle_get_clips({})
+
+        assert result["track_index"] is None
+        assert len(result["clips"]) == 3
+        assert [clip["track_index"] for clip in result["clips"]] == [1, 1, 2]
+
+    def test_serialization_shape(self, arrangement_handler: ArrangementHandler) -> None:
+        result = arrangement_handler.handle_get_clips({"track_index": 2})
+
+        assert result["clips"] == [
+            {
+                "track_index": 2,
+                "clip_index": 1,
+                "name": "Vocal",
+                "start_time": 4.0,
+                "end_time": 12.0,
+                "length": 8.0,
+                "is_audio_clip": True,
+                "is_midi_clip": False,
+            }
+        ]
+
+    def test_missing_track_raises_not_found(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="Track 99"):
+            arrangement_handler.handle_get_clips({"track_index": 99})
+
+
+class TestCreateArrangementClip:
+    def test_success_on_midi_track(
+        self,
+        arrangement_handler: ArrangementHandler,
+        arrangement_song: _ArrangementSong,
+    ) -> None:
+        result = arrangement_handler.handle_create_clip(
+            {"track_index": 1, "start_time": 24.0, "length": 8.0}
+        )
+
+        assert result == {
+            "track_index": 1,
+            "clip_index": 3,
+            "start_time": 24.0,
+            "length": 8.0,
+            "name": "New MIDI Clip",
+        }
+        assert len(arrangement_song.tracks[0].arrangement_clips) == 3
+
+    def test_rejects_non_midi_track(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="does not accept MIDI clips"):
+            arrangement_handler.handle_create_clip(
+                {"track_index": 2, "start_time": 8.0, "length": 4.0}
+            )
+
+
+class TestMoveArrangementClip:
+    def test_same_track_success(
+        self,
+        arrangement_handler: ArrangementHandler,
+        arrangement_song: _ArrangementSong,
+    ) -> None:
+        result = arrangement_handler.handle_move_clip(
+            {
+                "track_index": 1,
+                "clip_index": 1,
+                "new_start_time": 24.0,
+            }
+        )
+
+        assert result == {
+            "source_track_index": 1,
+            "source_clip_index": 1,
+            "target_track_index": 1,
+            "target_clip_index": 2,
+            "start_time": 24.0,
+        }
+        clips = arrangement_song.tracks[0].arrangement_clips
+        assert [clip.name for clip in clips] == ["Hook", "Verse Copy"]
+        assert [clip.start_time for clip in clips] == [16.0, 24.0]
+
+    def test_cross_track_success(
+        self,
+        arrangement_handler: ArrangementHandler,
+        arrangement_song: _ArrangementSong,
+    ) -> None:
+        result = arrangement_handler.handle_move_clip(
+            {
+                "track_index": 1,
+                "clip_index": 2,
+                "new_start_time": 32.0,
+                "new_track_index": 3,
+            }
+        )
+
+        assert result == {
+            "source_track_index": 1,
+            "source_clip_index": 2,
+            "target_track_index": 3,
+            "target_clip_index": 1,
+            "start_time": 32.0,
+        }
+        assert len(arrangement_song.tracks[0].arrangement_clips) == 1
+        assert arrangement_song.tracks[2].arrangement_clips[0].name == "Hook Copy"
+
+    def test_missing_clip_raises_not_found(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="Arrangement clip 99"):
+            arrangement_handler.handle_move_clip(
+                {
+                    "track_index": 1,
+                    "clip_index": 99,
+                    "new_start_time": 8.0,
+                }
+            )
+
+    def test_cross_track_rejects_incompatible_target(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="does not accept MIDI"):
+            arrangement_handler.handle_move_clip(
+                {
+                    "track_index": 1,
+                    "clip_index": 1,
+                    "new_start_time": 8.0,
+                    "new_track_index": 2,
+                }
+            )
+
+
+class TestArrangementLengthAndLoop:
+    def test_get_length_reads_song_length(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        result = arrangement_handler.handle_get_length({})
+
+        assert result == {"song_length": 96.0}
+
+    def test_set_loop_success(
+        self,
+        arrangement_handler: ArrangementHandler,
+        arrangement_song: _ArrangementSong,
+    ) -> None:
+        result = arrangement_handler.handle_set_loop(
+            {"start_time": 8.0, "end_time": 24.0, "enabled": True}
+        )
+
+        assert result == {"start_time": 8.0, "end_time": 24.0, "enabled": True}
+        assert arrangement_song.loop is True
+        assert arrangement_song.loop_start == 8.0
+        assert arrangement_song.loop_length == 16.0
+
+    def test_set_loop_rejects_invalid_range(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="end_time"):
+            arrangement_handler.handle_set_loop(
+                {"start_time": 8.0, "end_time": 8.0, "enabled": True}
+            )
+
+    def test_set_loop_requires_boolean_enabled(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="enabled"):
+            arrangement_handler.handle_set_loop(
+                {"start_time": 8.0, "end_time": 16.0, "enabled": "yes"}
+            )
+
+    def test_set_loop_returns_requested_state_when_live_read_lags(self) -> None:
+        laggy_song = _LaggyLoopSong()
+        handler = ArrangementHandler(_FakeControlSurface(laggy_song))
+
+        result = handler.handle_set_loop(
+            {"start_time": 12.0, "end_time": 20.0, "enabled": True}
+        )
+
+        assert result == {"start_time": 12.0, "end_time": 20.0, "enabled": True}
+        assert laggy_song._loop_current is True
+
+
+class TestDispatcherIntegration:
+    def test_arrangement_get_length_via_dispatcher(
+        self,
+        arrangement_song: _ArrangementSong,
+    ) -> None:
+        control_surface = _FakeControlSurface(arrangement_song)
+        dispatcher = Dispatcher(control_surface)
+        dispatcher.register("arrangement", ArrangementHandler(control_surface))
+
+        response = dispatcher.dispatch("arrangement.get_length", {}, "arr-1")
+
+        assert response["status"] == "ok"
+        assert response["result"] == {"song_length": 96.0}

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -94,6 +94,25 @@ class _MixerHandler:
         }
 
 
+class _ArrangementHandler:
+    def handle_get_clips(self, params):
+        return {
+            "track_index": None,
+            "clips": [
+                {
+                    "track_index": 1,
+                    "clip_index": 1,
+                    "name": "Verse",
+                    "start_time": 0.0,
+                    "end_time": 8.0,
+                    "length": 8.0,
+                    "is_audio_clip": False,
+                    "is_midi_clip": True,
+                }
+            ],
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
@@ -103,6 +122,7 @@ def tcp_server():
     dispatcher.register("browser", _BrowserHandler())
     dispatcher.register("device", _DeviceHandler())
     dispatcher.register("mixer", _MixerHandler())
+    dispatcher.register("arrangement", _ArrangementHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -223,5 +243,22 @@ class TestFullRoundTrip:
             "volume": 0.88,
             "pan": 0.0,
         }
+
+        await conn.disconnect()
+
+    async def test_arrangement_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="arrangement.get_clips", id="arrangement-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "arrangement-1"
+        assert resp.result is not None
+        assert resp.result["track_index"] is None
+        assert resp.result["clips"][0]["name"] == "Verse"
+        assert resp.result["clips"][0]["is_midi_clip"] is True
 
         await conn.disconnect()

--- a/Tests/tools/test_arrangement.py
+++ b/Tests/tools/test_arrangement.py
@@ -1,0 +1,386 @@
+"""Tests for arrangement MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.arrangement import (
+    ArrangementClipCreatedResult,
+    ArrangementClipInfo,
+    ArrangementClipMovedResult,
+    ArrangementClipsResult,
+    ArrangementLengthResult,
+    ArrangementLoopResult,
+    create_arrangement_clip,
+    get_arrangement_clips,
+    get_arrangement_length,
+    move_arrangement_clip,
+    set_arrangement_loop,
+)
+
+TOOL_NAMES = [
+    "get_arrangement_clips",
+    "create_arrangement_clip",
+    "move_arrangement_clip",
+    "get_arrangement_length",
+    "set_arrangement_loop",
+]
+
+ARRANGEMENT_CLIPS_RESULT = {
+    "track_index": None,
+    "clips": [
+        {
+            "track_index": 1,
+            "clip_index": 1,
+            "name": "Verse",
+            "start_time": 0.0,
+            "end_time": 8.0,
+            "length": 8.0,
+            "is_audio_clip": False,
+            "is_midi_clip": True,
+        },
+        {
+            "track_index": 2,
+            "clip_index": 1,
+            "name": "Vocal",
+            "start_time": 4.0,
+            "end_time": 12.0,
+            "length": 8.0,
+            "is_audio_clip": True,
+            "is_midi_clip": False,
+        },
+    ],
+}
+
+
+def _ok_response(result: dict[str, Any], request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+def _schema_minimum(schema: dict[str, Any]) -> int | float | None:
+    if "minimum" in schema:
+        return schema["minimum"]
+    for option in schema.get("anyOf", []):
+        if "minimum" in option:
+            return option["minimum"]
+    return None
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_get_arrangement_clips_schema(self) -> None:
+        tool = self._get_tool("get_arrangement_clips")
+        props = tool.parameters["properties"]
+        assert "track_index" in props
+        assert _schema_minimum(props["track_index"]) == 1
+
+    def test_move_arrangement_clip_schema(self) -> None:
+        tool = self._get_tool("move_arrangement_clip")
+        props = tool.parameters["properties"]
+        assert props["clip_index"]["minimum"] == 1
+        assert props["new_start_time"]["minimum"] == 0.0
+        assert _schema_minimum(props["new_track_index"]) == 1
+
+    def test_set_arrangement_loop_schema_defaults(self) -> None:
+        tool = self._get_tool("set_arrangement_loop")
+        props = tool.parameters["properties"]
+        assert props["start_time"]["minimum"] == 0.0
+        assert props["end_time"]["minimum"] == 0.0
+        assert props["enabled"]["default"] is True
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    def test_get_arrangement_clips_accepts_omitted_track_index(self) -> None:
+        model = self._arg_model("get_arrangement_clips")
+        args = model()
+        assert args.track_index is None
+
+    @pytest.mark.parametrize("track_index", [0, -1])
+    def test_create_arrangement_clip_rejects_bad_track_index(
+        self,
+        track_index: int,
+    ) -> None:
+        model = self._arg_model("create_arrangement_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=track_index, start_time=0.0, length=4.0)
+
+    def test_create_arrangement_clip_rejects_negative_start_time(self) -> None:
+        model = self._arg_model("create_arrangement_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, start_time=-1.0, length=4.0)
+
+    def test_create_arrangement_clip_rejects_non_positive_length(self) -> None:
+        model = self._arg_model("create_arrangement_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, start_time=0.0, length=0.0)
+
+    def test_move_arrangement_clip_rejects_non_positive_clip_index(self) -> None:
+        model = self._arg_model("move_arrangement_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_index=0, new_start_time=4.0)
+
+    def test_move_arrangement_clip_rejects_negative_start_time(self) -> None:
+        model = self._arg_model("move_arrangement_clip")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_index=1, new_start_time=-0.5)
+
+    def test_set_arrangement_loop_rejects_negative_end_time(self) -> None:
+        model = self._arg_model("set_arrangement_loop")
+        with pytest.raises(ValidationError):
+            model(start_time=0.0, end_time=-1.0)
+
+
+class TestGetArrangementClips:
+    async def test_returns_arrangement_clips(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            ARRANGEMENT_CLIPS_RESULT
+        )
+
+        result = await get_arrangement_clips(ctx=mock_context)
+
+        assert isinstance(result, ArrangementClipsResult)
+        assert result.track_index is None
+        assert len(result.clips) == 2
+        assert isinstance(result.clips[0], ArrangementClipInfo)
+        assert result.clips[1].is_audio_clip is True
+
+    async def test_sends_empty_params_when_track_index_omitted(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            ARRANGEMENT_CLIPS_RESULT
+        )
+
+        await get_arrangement_clips(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.get_clips"
+        assert req.params == {}
+
+    async def test_sends_track_index_when_provided(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "track_index": 2,
+                "clips": [ARRANGEMENT_CLIPS_RESULT["clips"][1]],
+            }
+        )
+
+        await get_arrangement_clips(ctx=mock_context, track_index=2)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.params == {"track_index": 2}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Track 9 does not exist",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_arrangement_clips(ctx=mock_context, track_index=9)
+
+
+class TestCreateArrangementClip:
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "track_index": 1,
+                "clip_index": 2,
+                "start_time": 16.0,
+                "length": 8.0,
+                "name": "New MIDI Clip",
+            }
+        )
+
+        result = await create_arrangement_clip(
+            ctx=mock_context,
+            track_index=1,
+            start_time=16.0,
+            length=8.0,
+        )
+
+        assert isinstance(result, ArrangementClipCreatedResult)
+        assert result.clip_index == 2
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.create_clip"
+        assert req.params == {
+            "track_index": 1,
+            "start_time": 16.0,
+            "length": 8.0,
+        }
+
+
+class TestMoveArrangementClip:
+    async def test_sends_correct_command_with_optional_track(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "source_track_index": 1,
+                "source_clip_index": 1,
+                "target_track_index": 2,
+                "target_clip_index": 1,
+                "start_time": 24.0,
+            }
+        )
+
+        result = await move_arrangement_clip(
+            ctx=mock_context,
+            track_index=1,
+            clip_index=1,
+            new_start_time=24.0,
+            new_track_index=2,
+        )
+
+        assert isinstance(result, ArrangementClipMovedResult)
+        assert result.target_track_index == 2
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.move_clip"
+        assert req.params == {
+            "track_index": 1,
+            "clip_index": 1,
+            "new_start_time": 24.0,
+            "new_track_index": 2,
+        }
+
+    async def test_omits_optional_target_track_when_missing(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "source_track_index": 1,
+                "source_clip_index": 1,
+                "target_track_index": 1,
+                "target_clip_index": 1,
+                "start_time": 12.0,
+            }
+        )
+
+        await move_arrangement_clip(
+            ctx=mock_context,
+            track_index=1,
+            clip_index=1,
+            new_start_time=12.0,
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.params == {
+            "track_index": 1,
+            "clip_index": 1,
+            "new_start_time": 12.0,
+        }
+
+
+class TestArrangementLengthAndLoop:
+    async def test_get_arrangement_length(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"song_length": 128.0})
+
+        result = await get_arrangement_length(ctx=mock_context)
+
+        assert isinstance(result, ArrangementLengthResult)
+        assert result.song_length == 128.0
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.get_length"
+        assert req.params == {}
+
+    async def test_set_arrangement_loop(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"start_time": 8.0, "end_time": 16.0, "enabled": False}
+        )
+
+        result = await set_arrangement_loop(
+            ctx=mock_context,
+            start_time=8.0,
+            end_time=16.0,
+            enabled=False,
+        )
+
+        assert isinstance(result, ArrangementLoopResult)
+        assert result.enabled is False
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.set_loop"
+        assert req.params == {
+            "start_time": 8.0,
+            "end_time": 16.0,
+            "enabled": False,
+        }
+
+    async def test_set_arrangement_loop_rejects_invalid_range(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        with pytest.raises(ValueError, match="end_time"):
+            await set_arrangement_loop(
+                ctx=mock_context,
+                start_time=8.0,
+                end_time=8.0,
+            )
+
+        mock_connection.send_command.assert_not_called()

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -494,6 +494,11 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `create_clip` | `clip.create` |
 | `add_notes_to_clip` | `clip.add_notes` |
 | `get_clip_notes` | `clip.get_notes` |
+| `get_arrangement_clips` | `arrangement.get_clips` |
+| `create_arrangement_clip` | `arrangement.create_clip` |
+| `move_arrangement_clip` | `arrangement.move_clip` |
+| `get_arrangement_length` | `arrangement.get_length` |
+| `set_arrangement_loop` | `arrangement.set_loop` |
 | `get_device_parameters` | `device.get_parameters` |
 | `set_device_parameter` | `device.set_parameter` |
 | `load_instrument` | `browser.load_instrument` |

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -50,6 +50,7 @@ class AbletonLiveMCP(ControlSurface):
 
     def _register_handlers(self) -> None:
         """Register command handlers with the dispatcher."""
+        from .handlers.arrangement import ArrangementHandler
         from .handlers.browser import BrowserHandler
         from .handlers.clip import ClipHandler
         from .handlers.device import DeviceHandler
@@ -61,6 +62,7 @@ class AbletonLiveMCP(ControlSurface):
         self._dispatcher.register("track", TrackHandler(self))
         self._dispatcher.register("device", DeviceHandler(self))
         self._dispatcher.register("clip", ClipHandler(self))
+        self._dispatcher.register("arrangement", ArrangementHandler(self))
         self._dispatcher.register("browser", BrowserHandler(self))
         self._dispatcher.register("mixer", MixerHandler(self))
 

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -4,6 +4,7 @@ Handler modules (session, track, clip, etc.) will be added by subsequent
 issues as the tool surface grows.
 """
 
+from .arrangement import ArrangementHandler
 from .browser import BrowserHandler
 from .clip import ClipHandler
 from .device import DeviceHandler
@@ -12,6 +13,7 @@ from .session import SessionHandler
 from .track import TrackHandler
 
 __all__ = [
+    "ArrangementHandler",
     "BrowserHandler",
     "ClipHandler",
     "DeviceHandler",

--- a/remote_script/AbletonLiveMCP/handlers/arrangement.py
+++ b/remote_script/AbletonLiveMCP/handlers/arrangement.py
@@ -1,0 +1,370 @@
+"""Arrangement command handlers for the Ableton Live MCP Remote Script."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class ArrangementHandler(BaseHandler):
+    """Handle arrangement clip and loop commands."""
+
+    def _resolve_track(self, track_index: int) -> tuple[Any, int, int]:
+        """Return ``(track, track_index_1based, lo_track)`` or raise."""
+        tracks = self._song.tracks
+        track_count = len(tracks)
+        if track_index > track_count:
+            raise NotFoundError(
+                f"Track {track_index} does not exist (song has {track_count} track(s))"
+            )
+        lo_track = track_index - 1
+        return tracks[lo_track], track_index, lo_track
+
+    def _require_track_index(
+        self,
+        params: dict[str, Any],
+        key: str,
+        *,
+        required: bool = True,
+    ) -> int | None:
+        raw = params.get(key)
+        if raw is None:
+            if required:
+                raise InvalidParamsError(f"'{key}' parameter is required")
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise InvalidParamsError(f"'{key}' must be an integer")
+        if raw < 1:
+            raise InvalidParamsError(f"'{key}' must be at least 1")
+        return raw
+
+    def _require_clip_index(self, params: dict[str, Any]) -> int:
+        raw = params.get("clip_index")
+        if raw is None:
+            raise InvalidParamsError("'clip_index' parameter is required")
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise InvalidParamsError("'clip_index' must be an integer")
+        if raw < 1:
+            raise InvalidParamsError("'clip_index' must be at least 1")
+        return raw
+
+    def _require_number(
+        self,
+        params: dict[str, Any],
+        key: str,
+        *,
+        minimum: float | None = None,
+        exclusive_minimum: bool = False,
+    ) -> float:
+        raw = params.get(key)
+        if raw is None:
+            raise InvalidParamsError(f"'{key}' parameter is required")
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise InvalidParamsError(f"'{key}' must be a number")
+
+        value = float(raw)
+        if minimum is not None:
+            if exclusive_minimum and value <= minimum:
+                raise InvalidParamsError(f"'{key}' must be greater than {minimum}")
+            if not exclusive_minimum and value < minimum:
+                raise InvalidParamsError(f"'{key}' must be at least {minimum}")
+        return value
+
+    def _serialize_clip(
+        self,
+        clip: Any,
+        *,
+        track_index: int,
+        clip_index: int,
+    ) -> dict[str, Any]:
+        start_time = float(clip.start_time)
+        end_time = float(clip.end_time)
+        return {
+            "track_index": track_index,
+            "clip_index": clip_index,
+            "name": str(clip.name),
+            "start_time": start_time,
+            "end_time": end_time,
+            "length": float(clip.length),
+            "is_audio_clip": bool(clip.is_audio_clip),
+            "is_midi_clip": bool(clip.is_midi_clip),
+        }
+
+    def _clip_signature(self, clip: Any) -> tuple[str, float, float, float, bool, bool]:
+        return (
+            str(clip.name),
+            float(clip.start_time),
+            float(clip.end_time),
+            float(clip.length),
+            bool(clip.is_audio_clip),
+            bool(clip.is_midi_clip),
+        )
+
+    def _get_arrangement_clips(
+        self,
+        track: Any,
+        track_index: int,
+    ) -> list[dict[str, Any]]:
+        clips: list[dict[str, Any]] = []
+        for clip_index, clip in enumerate(track.arrangement_clips, start=1):
+            clips.append(
+                self._serialize_clip(
+                    clip,
+                    track_index=track_index,
+                    clip_index=clip_index,
+                )
+            )
+        return clips
+
+    def _resolve_arrangement_clip(
+        self,
+        track: Any,
+        *,
+        track_index: int,
+        clip_index: int,
+    ) -> Any:
+        clips = track.arrangement_clips
+        clip_count = len(clips)
+        if clip_index > clip_count:
+            raise NotFoundError(
+                "Arrangement clip "
+                f"{clip_index} does not exist on track {track_index} "
+                f"(track has {clip_count} arrangement clip(s))"
+            )
+        return clips[clip_index - 1]
+
+    def _find_new_clip(
+        self,
+        before: list[Any],
+        after: list[Any],
+        *,
+        action: str,
+    ) -> tuple[int, Any]:
+        before_counts = Counter(id(clip) for clip in before)
+        seen_counts: Counter[int] = Counter()
+        candidates: list[tuple[int, Any]] = []
+
+        for clip_index, clip in enumerate(after, start=1):
+            clip_id = id(clip)
+            seen_counts[clip_id] += 1
+            if seen_counts[clip_id] > before_counts[clip_id]:
+                candidates.append((clip_index, clip))
+
+        if len(candidates) == 1:
+            return candidates[0]
+
+        signature_before_counts = Counter(self._clip_signature(clip) for clip in before)
+        signature_seen_counts: Counter[tuple[str, float, float, float, bool, bool]]
+        signature_seen_counts = Counter()
+        signature_candidates: list[tuple[int, Any]] = []
+
+        for clip_index, clip in enumerate(after, start=1):
+            signature = self._clip_signature(clip)
+            signature_seen_counts[signature] += 1
+            if signature_seen_counts[signature] > signature_before_counts[signature]:
+                signature_candidates.append((clip_index, clip))
+
+        if not signature_candidates:
+            raise RuntimeError(
+                f"No new arrangement clip appeared after {action} completed"
+            )
+        if len(signature_candidates) > 1:
+            raise RuntimeError(
+                f"Could not uniquely identify the arrangement clip after {action}"
+            )
+        return signature_candidates[0]
+
+    def _find_clip_index(self, track: Any, clip: Any, track_index: int) -> int:
+        for clip_index, candidate in enumerate(track.arrangement_clips, start=1):
+            if candidate is clip:
+                return clip_index
+
+        clip_signature = self._clip_signature(clip)
+        signature_matches = [
+            clip_index
+            for clip_index, candidate in enumerate(track.arrangement_clips, start=1)
+            if self._clip_signature(candidate) == clip_signature
+        ]
+        if len(signature_matches) == 1:
+            return signature_matches[0]
+
+        raise RuntimeError(
+            f"Could not locate arrangement clip on track {track_index} after update"
+        )
+
+    def _validate_target_track(
+        self,
+        clip: Any,
+        target_track: Any,
+        target_track_index: int,
+    ) -> None:
+        if bool(clip.is_midi_clip) and not bool(target_track.has_midi_input):
+            raise InvalidParamsError(
+                f"Track {target_track_index} does not accept MIDI arrangement clips"
+            )
+        if bool(clip.is_audio_clip) and not bool(target_track.has_audio_input):
+            raise InvalidParamsError(
+                f"Track {target_track_index} does not accept audio arrangement clips"
+            )
+
+    def handle_get_clips(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return arrangement clips for one track or all tracks."""
+        track_index = self._require_track_index(params, "track_index", required=False)
+
+        def _read() -> dict[str, Any]:
+            if track_index is not None:
+                track, resolved_track_index, _ = self._resolve_track(track_index)
+                return {
+                    "track_index": resolved_track_index,
+                    "clips": self._get_arrangement_clips(track, resolved_track_index),
+                }
+
+            clips: list[dict[str, Any]] = []
+            for resolved_track_index, track in enumerate(self._song.tracks, start=1):
+                clips.extend(self._get_arrangement_clips(track, resolved_track_index))
+            return {"track_index": None, "clips": clips}
+
+        return self._run_on_main_thread(_read)
+
+    def handle_create_clip(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Create an empty MIDI arrangement clip on a MIDI track."""
+        track_index = self._require_track_index(params, "track_index")
+        assert track_index is not None
+        start_time = self._require_number(params, "start_time", minimum=0.0)
+        length = self._require_number(
+            params,
+            "length",
+            minimum=0.0,
+            exclusive_minimum=True,
+        )
+
+        def _create() -> dict[str, Any]:
+            track, resolved_track_index, _ = self._resolve_track(track_index)
+            if not bool(track.has_midi_input):
+                raise InvalidParamsError(
+                    f"Track {resolved_track_index} does not accept MIDI clips"
+                )
+
+            before = list(track.arrangement_clips)
+            track.create_midi_clip(start_time, length)
+            clip_index, clip = self._find_new_clip(
+                before,
+                list(track.arrangement_clips),
+                action="create_arrangement_clip",
+            )
+            return {
+                "track_index": resolved_track_index,
+                "clip_index": clip_index,
+                "start_time": start_time,
+                "length": length,
+                "name": str(clip.name),
+            }
+
+        return self._run_on_main_thread(_create)
+
+    def handle_move_clip(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Move an arrangement clip to a new track/time by duplicate-then-delete."""
+        source_track_index = self._require_track_index(params, "track_index")
+        assert source_track_index is not None
+        source_clip_index = self._require_clip_index(params)
+        new_start_time = self._require_number(params, "new_start_time", minimum=0.0)
+        target_track_index = self._require_track_index(
+            params,
+            "new_track_index",
+            required=False,
+        )
+        if target_track_index is None:
+            target_track_index = source_track_index
+
+        def _move() -> dict[str, Any]:
+            source_track, resolved_source_track_index, _ = self._resolve_track(
+                source_track_index
+            )
+            source_clip = self._resolve_arrangement_clip(
+                source_track,
+                track_index=resolved_source_track_index,
+                clip_index=source_clip_index,
+            )
+            target_track, resolved_target_track_index, _ = self._resolve_track(
+                target_track_index
+            )
+            self._validate_target_track(
+                source_clip,
+                target_track,
+                resolved_target_track_index,
+            )
+
+            before_target = list(target_track.arrangement_clips)
+            try:
+                target_track.duplicate_clip_to_arrangement(source_clip, new_start_time)
+            except Exception as exc:
+                raise InvalidParamsError(
+                    "Unable to duplicate arrangement clip to the target track/time: "
+                    f"{exc}"
+                ) from exc
+
+            _target_clip_index, moved_clip = self._find_new_clip(
+                before_target,
+                list(target_track.arrangement_clips),
+                action="move_arrangement_clip",
+            )
+
+            try:
+                source_track.delete_clip(source_clip)
+            except Exception as exc:
+                raise RuntimeError(
+                    "Arrangement clip duplication succeeded but deleting the original "
+                    f"clip failed: {exc}"
+                ) from exc
+
+            final_target_clip_index = self._find_clip_index(
+                target_track,
+                moved_clip,
+                resolved_target_track_index,
+            )
+            return {
+                "source_track_index": resolved_source_track_index,
+                "source_clip_index": source_clip_index,
+                "target_track_index": resolved_target_track_index,
+                "target_clip_index": final_target_clip_index,
+                "start_time": float(moved_clip.start_time),
+            }
+
+        return self._run_on_main_thread(_move)
+
+    def handle_get_length(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return the song's arrangement length in beats."""
+
+        def _read() -> dict[str, Any]:
+            return {"song_length": float(self._song.song_length)}
+
+        return self._run_on_main_thread(_read)
+
+    def handle_set_loop(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set arrangement loop start/end/enabled."""
+        start_time = self._require_number(params, "start_time", minimum=0.0)
+        end_time = self._require_number(params, "end_time", minimum=0.0)
+        enabled = params.get("enabled", True)
+        if not isinstance(enabled, bool):
+            raise InvalidParamsError("'enabled' must be a boolean")
+        if end_time <= start_time:
+            raise InvalidParamsError("'end_time' must be greater than 'start_time'")
+
+        def _set() -> dict[str, Any]:
+            song = self._song
+            song.loop_start = start_time
+            song.loop_length = end_time - start_time
+            song.loop = enabled
+            return {
+                "start_time": float(song.loop_start),
+                "end_time": float(song.loop_start + song.loop_length),
+                "enabled": enabled,
+            }
+
+        return self._run_on_main_thread(_set)
+
+
+__all__ = ["ArrangementHandler"]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tool modules for the Ableton MCP server."""
 
+import mcp_ableton.tools.arrangement  # noqa: F401
 import mcp_ableton.tools.browser  # noqa: F401
 import mcp_ableton.tools.clip  # noqa: F401
 import mcp_ableton.tools.device  # noqa: F401

--- a/src/mcp_ableton/tools/arrangement.py
+++ b/src/mcp_ableton/tools/arrangement.py
@@ -1,0 +1,243 @@
+"""MCP tools for Ableton Live arrangement view clip operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+TrackIndex = Annotated[
+    int,
+    Field(
+        description="1-based index of the track.",
+        ge=1,
+    ),
+]
+ClipIndex = Annotated[
+    int,
+    Field(
+        description=(
+            "1-based clip index within the track's arrangement_clips collection."
+        ),
+        ge=1,
+    ),
+]
+StartTime = Annotated[
+    float,
+    Field(
+        description="Beat time in arrangement space (must be >= 0).",
+        ge=0.0,
+    ),
+]
+PositiveLength = Annotated[
+    float,
+    Field(
+        description="Clip length in beats (must be > 0).",
+        gt=0.0,
+    ),
+]
+
+
+class ArrangementClipInfo(BaseModel):
+    """Arrangement clip metadata returned by ``get_arrangement_clips``."""
+
+    track_index: int
+    clip_index: int
+    name: str
+    start_time: float
+    end_time: float
+    length: float
+    is_audio_clip: bool
+    is_midi_clip: bool
+
+
+class ArrangementClipsResult(BaseModel):
+    """Arrangement clip listing for one track or the whole song."""
+
+    track_index: int | None
+    clips: list[ArrangementClipInfo]
+
+
+class ArrangementClipCreatedResult(BaseModel):
+    """Result of ``create_arrangement_clip``."""
+
+    track_index: int
+    clip_index: int
+    start_time: float
+    length: float
+    name: str
+
+
+class ArrangementClipMovedResult(BaseModel):
+    """Result of ``move_arrangement_clip``."""
+
+    source_track_index: int
+    source_clip_index: int
+    target_track_index: int
+    target_clip_index: int
+    start_time: float
+
+
+class ArrangementLengthResult(BaseModel):
+    """Total arrangement length returned by ``get_arrangement_length``."""
+
+    song_length: float
+
+
+class ArrangementLoopResult(BaseModel):
+    """Result of ``set_arrangement_loop``."""
+
+    start_time: float
+    end_time: float
+    enabled: bool
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def get_arrangement_clips(
+    ctx: Context,
+    track_index: Annotated[
+        TrackIndex | None,
+        Field(
+            description=(
+                "Optional 1-based track index. When omitted, returns clips across all "
+                "tracks."
+            ),
+        ),
+    ] = None,
+) -> ArrangementClipsResult:
+    """Get arrangement clips for one track or for all tracks."""
+    connection = _get_connection(ctx)
+    params: dict[str, int] = {}
+    if track_index is not None:
+        params["track_index"] = track_index
+    request = CommandRequest(command="arrangement.get_clips", params=params)
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementClipsResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def create_arrangement_clip(
+    ctx: Context,
+    track_index: TrackIndex,
+    start_time: StartTime,
+    length: PositiveLength,
+) -> ArrangementClipCreatedResult:
+    """Create an empty MIDI arrangement clip on a MIDI track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="arrangement.create_clip",
+        params={
+            "track_index": track_index,
+            "start_time": start_time,
+            "length": length,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementClipCreatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def move_arrangement_clip(
+    ctx: Context,
+    track_index: TrackIndex,
+    clip_index: ClipIndex,
+    new_start_time: Annotated[
+        float,
+        Field(
+            description="New arrangement start time in beats (must be >= 0).", ge=0.0
+        ),
+    ],
+    new_track_index: Annotated[
+        TrackIndex | None,
+        Field(
+            description=(
+                "Optional 1-based target track index. When omitted, the clip stays "
+                "on the source track."
+            ),
+        ),
+    ] = None,
+) -> ArrangementClipMovedResult:
+    """Move an arrangement clip by duplicating it and deleting the original."""
+    connection = _get_connection(ctx)
+    params: dict[str, int | float] = {
+        "track_index": track_index,
+        "clip_index": clip_index,
+        "new_start_time": new_start_time,
+    }
+    if new_track_index is not None:
+        params["new_track_index"] = new_track_index
+    request = CommandRequest(command="arrangement.move_clip", params=params)
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementClipMovedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_arrangement_length(ctx: Context) -> ArrangementLengthResult:
+    """Get the total arrangement length in beats."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(command="arrangement.get_length")
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementLengthResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_arrangement_loop(
+    ctx: Context,
+    start_time: StartTime,
+    end_time: Annotated[
+        float,
+        Field(description="Arrangement loop end time in beats (must be >= 0).", ge=0.0),
+    ],
+    enabled: Annotated[
+        bool,
+        Field(description="Whether the arrangement loop is enabled."),
+    ] = True,
+) -> ArrangementLoopResult:
+    """Set the arrangement loop range and enabled state."""
+    if end_time <= start_time:
+        raise ValueError("'end_time' must be greater than 'start_time'")
+
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="arrangement.set_loop",
+        params={
+            "start_time": start_time,
+            "end_time": end_time,
+            "enabled": enabled,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementLoopResult.model_validate(response.result)
+
+
+__all__ = [
+    "ArrangementClipCreatedResult",
+    "ArrangementClipInfo",
+    "ArrangementClipMovedResult",
+    "ArrangementClipsResult",
+    "ArrangementLengthResult",
+    "ArrangementLoopResult",
+    "create_arrangement_clip",
+    "get_arrangement_clips",
+    "get_arrangement_length",
+    "move_arrangement_clip",
+    "set_arrangement_loop",
+]


### PR DESCRIPTION
## Summary
- add a dedicated MCP arrangement tool module with typed Pydantic request/response handling
- add a dedicated Remote Script arrangement handler and `arrangement.*` dispatcher registration
- ship arrangement docs/test coverage and verify the Live 12.2.5 runtime behavior through the stdio MCP server path

## MCP tools
- add `get_arrangement_clips`
- add `create_arrangement_clip`
- add `move_arrangement_clip`
- add `get_arrangement_length`
- add `set_arrangement_loop`
- register the arrangement tool module from `src/mcp_ableton/tools/__init__.py`

## Remote Script
- add `remote_script/AbletonLiveMCP/handlers/arrangement.py`
- register the `arrangement` handler category in `remote_script/AbletonLiveMCP/__init__.py`
- keep arrangement reads/writes on Ableton's main thread and infer created/moved clips by before/after arrangement clip diffs
- handle the Live 12.2.5 loop-state readback lag by returning the requested enabled state after writing `song.loop`

## Tests
- add `Tests/tools/test_arrangement.py`
- add `Tests/test_arrangement_handler.py`
- extend `Tests/test_integration.py` with an arrangement round-trip payload case
- validation run:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification
- Ableton Live 12.2.5 smoke-tested through the real stdio MCP server (`uv run mcp-ableton` via MCP stdio client), not direct TCP-only calls
- successful arrangement clip create: created an empty MIDI arrangement clip on temporary MIDI track 5 at beat 64.0 and confirmed it via `get_arrangement_clips`
- successful arrangement clip move: moved that clip from temporary MIDI track 5 to temporary MIDI track 6 at beat 96.0 and confirmed source/target arrangement state via `get_arrangement_clips`
- successful arrangement length read: `get_arrangement_length` returned `{"song_length": 232.0}`
- successful arrangement loop update and restoration: `set_arrangement_loop(8.0, 16.0, true)` returned the expected enabled state, then reset the disposable `Untitled` scratch set loop to `start_time=0.0`, `end_time=4.0`, `enabled=false`
- explicit INVALID_PARAMS case verified: `create_arrangement_clip` on temporary audio track 7 returned `[INVALID_PARAMS] Track 7 does not accept MIDI clips`
- Ableton `Log.txt` stayed clean for the smoke window: no Python traceback/exception lines were emitted after the verification baseline at line 56480

## Docs
- update the README status text to include arrangement clip support
- add the arrangement tool-to-command mappings to ADR-002

Closes #10
