### PR TITLE
Add scene management MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport**, **track management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session, track management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as scenes and extended mixing.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as sends/returns, recording, and undo/redo.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -113,6 +113,36 @@ class _ArrangementHandler:
         }
 
 
+class _SceneHandler:
+    def handle_get_all(self, params):
+        return {
+            "scenes": [
+                {
+                    "scene_index": 1,
+                    "name": "Intro",
+                    "is_empty": False,
+                    "is_triggered": False,
+                    "tempo_enabled": True,
+                    "tempo": 120.0,
+                    "time_signature_enabled": True,
+                    "time_signature_numerator": 4,
+                    "time_signature_denominator": 4,
+                },
+                {
+                    "scene_index": 2,
+                    "name": "Breakdown",
+                    "is_empty": True,
+                    "is_triggered": True,
+                    "tempo_enabled": False,
+                    "tempo": None,
+                    "time_signature_enabled": False,
+                    "time_signature_numerator": None,
+                    "time_signature_denominator": None,
+                },
+            ]
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
@@ -123,6 +153,7 @@ def tcp_server():
     dispatcher.register("device", _DeviceHandler())
     dispatcher.register("mixer", _MixerHandler())
     dispatcher.register("arrangement", _ArrangementHandler())
+    dispatcher.register("scene", _SceneHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -224,6 +255,23 @@ class TestFullRoundTrip:
         assert resp.result["device_name"] == "Analog"
         assert resp.result["parameters"][0]["parameter_index"] == 1
         assert resp.result["parameters"][1]["name"] == "Filter Freq"
+
+        await conn.disconnect()
+
+    async def test_scene_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="scene.get_all", id="scene-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "scene-1"
+        assert resp.result is not None
+        assert resp.result["scenes"][0]["name"] == "Intro"
+        assert resp.result["scenes"][1]["tempo"] is None
+        assert resp.result["scenes"][1]["time_signature_denominator"] is None
 
         await conn.disconnect()
 

--- a/Tests/test_scene_handler.py
+++ b/Tests/test_scene_handler.py
@@ -1,0 +1,299 @@
+"""Tests for the Remote Script SceneHandler."""
+
+from __future__ import annotations
+
+import pytest
+from AbletonLiveMCP.dispatcher import Dispatcher, InvalidParamsError, NotFoundError
+from AbletonLiveMCP.handlers.scene import SceneHandler
+
+
+class _ClipSlot:
+    def __init__(self) -> None:
+        self.stop_count = 0
+
+    def stop(self) -> None:
+        self.stop_count += 1
+
+
+class _Track:
+    def __init__(self, clip_slot_count: int) -> None:
+        self.clip_slots = [_ClipSlot() for _ in range(clip_slot_count)]
+
+
+class _Scene:
+    def __init__(
+        self,
+        name: str,
+        *,
+        is_empty: bool,
+        is_triggered: bool = False,
+        tempo_enabled: bool = False,
+        tempo: float = -1.0,
+        time_signature_enabled: bool = False,
+        time_signature_numerator: int = -1,
+        time_signature_denominator: int = -1,
+    ) -> None:
+        self.name = name
+        self.is_empty = is_empty
+        self.is_triggered = is_triggered
+        self.tempo_enabled = tempo_enabled
+        self.tempo = tempo
+        self.time_signature_enabled = time_signature_enabled
+        self.time_signature_numerator = time_signature_numerator
+        self.time_signature_denominator = time_signature_denominator
+        self.fire_count = 0
+
+    def fire(self) -> None:
+        self.fire_count += 1
+
+
+class _SceneSong:
+    def __init__(self) -> None:
+        self.scenes = [
+            _Scene(
+                "Intro",
+                is_empty=False,
+                tempo_enabled=True,
+                tempo=120.0,
+                time_signature_enabled=True,
+                time_signature_numerator=4,
+                time_signature_denominator=4,
+            ),
+            _Scene(
+                "Breakdown",
+                is_empty=True,
+                is_triggered=True,
+                tempo_enabled=False,
+                tempo=-1.0,
+                time_signature_enabled=False,
+                time_signature_numerator=-1,
+                time_signature_denominator=-1,
+            ),
+            _Scene("Outro", is_empty=False),
+        ]
+        self.tracks = [_Track(3), _Track(3)]
+
+    def create_scene(self, index: int) -> _Scene:
+        insert_index = len(self.scenes) if index == -1 else index
+        new_scene = _Scene(f"Scene {insert_index + 1}", is_empty=True)
+        self.scenes.insert(insert_index, new_scene)
+        for track in self.tracks:
+            track.clip_slots.insert(insert_index, _ClipSlot())
+        return new_scene
+
+    def delete_scene(self, index: int) -> None:
+        del self.scenes[index]
+        for track in self.tracks:
+            del track.clip_slots[index]
+
+    def duplicate_scene(self, index: int) -> None:
+        source = self.scenes[index]
+        duplicate = _Scene(
+            f"{source.name} Copy",
+            is_empty=source.is_empty,
+            is_triggered=source.is_triggered,
+            tempo_enabled=source.tempo_enabled,
+            tempo=source.tempo,
+            time_signature_enabled=source.time_signature_enabled,
+            time_signature_numerator=source.time_signature_numerator,
+            time_signature_denominator=source.time_signature_denominator,
+        )
+        self.scenes.insert(index + 1, duplicate)
+        for track in self.tracks:
+            track.clip_slots.insert(index + 1, _ClipSlot())
+
+
+class _FakeControlSurface:
+    def __init__(self, song: _SceneSong | None = None) -> None:
+        self._song = song or _SceneSong()
+
+    def song(self) -> _SceneSong:
+        return self._song
+
+    def log_message(self, msg: str) -> None:
+        pass
+
+    def show_message(self, msg: str) -> None:
+        pass
+
+    def schedule_message(self, delay, callback) -> None:
+        callback()
+
+
+@pytest.fixture
+def scene_song() -> _SceneSong:
+    return _SceneSong()
+
+
+@pytest.fixture
+def scene_handler(scene_song: _SceneSong) -> SceneHandler:
+    return SceneHandler(_FakeControlSurface(scene_song))
+
+
+class TestGetScenes:
+    def test_serializes_scene_shape(self, scene_handler: SceneHandler) -> None:
+        result = scene_handler.handle_get_all({})
+
+        assert result == {
+            "scenes": [
+                {
+                    "scene_index": 1,
+                    "name": "Intro",
+                    "is_empty": False,
+                    "is_triggered": False,
+                    "tempo_enabled": True,
+                    "tempo": 120.0,
+                    "time_signature_enabled": True,
+                    "time_signature_numerator": 4,
+                    "time_signature_denominator": 4,
+                },
+                {
+                    "scene_index": 2,
+                    "name": "Breakdown",
+                    "is_empty": True,
+                    "is_triggered": True,
+                    "tempo_enabled": False,
+                    "tempo": None,
+                    "time_signature_enabled": False,
+                    "time_signature_numerator": None,
+                    "time_signature_denominator": None,
+                },
+                {
+                    "scene_index": 3,
+                    "name": "Outro",
+                    "is_empty": False,
+                    "is_triggered": False,
+                    "tempo_enabled": False,
+                    "tempo": None,
+                    "time_signature_enabled": False,
+                    "time_signature_numerator": None,
+                    "time_signature_denominator": None,
+                },
+            ]
+        }
+
+
+class TestCreateScene:
+    def test_append_scene_by_default(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_create({})
+
+        assert result == {"scene_index": 4, "name": "Scene 4"}
+        assert len(scene_song.scenes) == 4
+        assert len(scene_song.tracks[0].clip_slots) == 4
+
+    def test_insert_scene_with_name(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_create({"index": 1, "name": "Bridge"})
+
+        assert result == {"scene_index": 2, "name": "Bridge"}
+        assert scene_song.scenes[1].name == "Bridge"
+        assert len(scene_song.tracks[1].clip_slots) == 4
+
+    def test_rejects_invalid_create_index(self, scene_handler: SceneHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="index"):
+            scene_handler.handle_create({"index": 99})
+
+    def test_rejects_empty_create_name(self, scene_handler: SceneHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="name"):
+            scene_handler.handle_create({"name": "  "})
+
+
+class TestSceneActions:
+    def test_duplicate_scene(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_duplicate({"scene_index": 1})
+
+        assert result == {"source_scene_index": 1, "new_scene_index": 2}
+        assert scene_song.scenes[1].name == "Intro Copy"
+
+    def test_delete_scene(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_delete({"scene_index": 2})
+
+        assert result == {"scene_index": 2}
+        assert [scene.name for scene in scene_song.scenes] == ["Intro", "Outro"]
+        assert len(scene_song.tracks[0].clip_slots) == 2
+
+    def test_fire_scene(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_fire({"scene_index": 2})
+
+        assert result == {"scene_index": 2}
+        assert scene_song.scenes[1].fire_count == 1
+
+    def test_stop_scene_only_targets_requested_row(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_stop({"scene_index": 2})
+
+        assert result == {"scene_index": 2}
+        for track in scene_song.tracks:
+            assert [slot.stop_count for slot in track.clip_slots] == [0, 1, 0]
+
+    def test_set_scene_name(
+        self,
+        scene_handler: SceneHandler,
+        scene_song: _SceneSong,
+    ) -> None:
+        result = scene_handler.handle_set_name({"scene_index": 3, "name": "Finale"})
+
+        assert result == {"scene_index": 3, "name": "Finale"}
+        assert scene_song.scenes[2].name == "Finale"
+
+
+class TestErrors:
+    def test_missing_scene_is_not_found(self, scene_handler: SceneHandler) -> None:
+        with pytest.raises(NotFoundError, match="Scene 99"):
+            scene_handler.handle_fire({"scene_index": 99})
+
+    def test_invalid_scene_index_is_invalid_params(
+        self,
+        scene_handler: SceneHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="scene_index"):
+            scene_handler.handle_delete({"scene_index": 0})
+
+    def test_invalid_name_is_invalid_params(self, scene_handler: SceneHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="name"):
+            scene_handler.handle_set_name({"scene_index": 1, "name": ""})
+
+
+class TestDispatcherIntegration:
+    def test_scene_not_found_maps_via_dispatcher(self, scene_song: _SceneSong) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface(scene_song))
+        dispatcher.register("scene", SceneHandler(_FakeControlSurface(scene_song)))
+
+        response = dispatcher.dispatch("scene.fire", {"scene_index": 10}, "scene-1")
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+
+    def test_scene_handler_is_registered_on_dispatcher_call(
+        self,
+        scene_song: _SceneSong,
+    ) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface(scene_song))
+        dispatcher.register("scene", SceneHandler(_FakeControlSurface(scene_song)))
+
+        response = dispatcher.dispatch("scene.get_all", {}, "scene-2")
+
+        assert response["status"] == "ok"
+        assert len(response["result"]["scenes"]) == 3

--- a/Tests/tools/test_scene.py
+++ b/Tests/tools/test_scene.py
@@ -1,0 +1,308 @@
+"""Tests for scene management MCP tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
+from mcp_ableton.tools.scene import (
+    SceneActionResult,
+    SceneCreatedResult,
+    SceneDeletedResult,
+    SceneDuplicatedResult,
+    SceneInfo,
+    SceneRenamedResult,
+    ScenesResult,
+    create_scene,
+    delete_scene,
+    duplicate_scene,
+    fire_scene,
+    get_scenes,
+    set_scene_name,
+    stop_scene,
+)
+
+TOOL_NAMES = [
+    "get_scenes",
+    "create_scene",
+    "delete_scene",
+    "duplicate_scene",
+    "fire_scene",
+    "stop_scene",
+    "set_scene_name",
+]
+
+SCENES_RESULT = {
+    "scenes": [
+        {
+            "scene_index": 1,
+            "name": "Intro",
+            "is_empty": False,
+            "is_triggered": False,
+            "tempo_enabled": True,
+            "tempo": 120.0,
+            "time_signature_enabled": True,
+            "time_signature_numerator": 4,
+            "time_signature_denominator": 4,
+        },
+        {
+            "scene_index": 2,
+            "name": "Breakdown",
+            "is_empty": True,
+            "is_triggered": True,
+            "tempo_enabled": False,
+            "tempo": None,
+            "time_signature_enabled": False,
+            "time_signature_numerator": None,
+            "time_signature_denominator": None,
+        },
+    ]
+}
+
+
+def _ok_response(result: dict[str, Any], request_id: str = "test") -> CommandResponse:
+    return CommandResponse(status="ok", result=result, id=request_id)
+
+
+def _error_response(
+    code: str = "INTERNAL_ERROR",
+    message: str = "something broke",
+    request_id: str = "test",
+) -> CommandResponse:
+    return CommandResponse(
+        status="error",
+        id=request_id,
+        error=ErrorDetail(code=code, message=message),
+    )
+
+
+class TestToolContracts:
+    def _get_tool(self, name: str):
+        tools = mcp._tool_manager._tools
+        assert name in tools, f"Tool '{name}' not registered"
+        return tools[name]
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_is_registered(self, name: str) -> None:
+        self._get_tool(name)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_tool_has_description(self, name: str) -> None:
+        tool = self._get_tool(name)
+        assert tool.description, f"Tool '{name}' is missing a description"
+
+    def test_create_scene_schema_defaults(self) -> None:
+        tool = self._get_tool("create_scene")
+        props = tool.parameters["properties"]
+        assert props["index"]["default"] == -1
+        assert props["index"]["minimum"] == -1
+
+    def test_scene_index_minimums(self) -> None:
+        tool = self._get_tool("delete_scene")
+        props = tool.parameters["properties"]
+        assert props["scene_index"]["minimum"] == 1
+
+    def test_set_scene_name_schema(self) -> None:
+        tool = self._get_tool("set_scene_name")
+        props = tool.parameters["properties"]
+        assert props["name"]["minLength"] == 1
+
+
+class TestInputValidation:
+    def _arg_model(self, tool_name: str):
+        return mcp._tool_manager._tools[tool_name].fn_metadata.arg_model
+
+    def test_create_scene_accepts_default_values(self) -> None:
+        model = self._arg_model("create_scene")
+        args = model()
+        assert args.index == -1
+        assert args.name is None
+
+    def test_create_scene_rejects_index_below_append_sentinel(self) -> None:
+        model = self._arg_model("create_scene")
+        with pytest.raises(ValidationError):
+            model(index=-2)
+
+    @pytest.mark.parametrize("scene_index", [0, -1])
+    def test_scene_actions_reject_non_positive_index(self, scene_index: int) -> None:
+        model = self._arg_model("fire_scene")
+        with pytest.raises(ValidationError):
+            model(scene_index=scene_index)
+
+    def test_set_scene_name_rejects_empty_name(self) -> None:
+        model = self._arg_model("set_scene_name")
+        with pytest.raises(ValidationError):
+            model(scene_index=1, name="")
+
+
+class TestGetScenes:
+    async def test_returns_scene_models(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(SCENES_RESULT)
+
+        result = await get_scenes(ctx=mock_context)
+
+        assert isinstance(result, ScenesResult)
+        assert len(result.scenes) == 2
+        assert isinstance(result.scenes[0], SceneInfo)
+        assert result.scenes[1].tempo is None
+        assert result.scenes[1].time_signature_numerator is None
+
+    async def test_sends_scene_get_all_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(SCENES_RESULT)
+
+        await get_scenes(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.get_all"
+        assert req.params == {}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INTERNAL_ERROR",
+            message="scene listing failed",
+        )
+
+        with pytest.raises(CommandError, match="INTERNAL_ERROR"):
+            await get_scenes(ctx=mock_context)
+
+
+class TestCreateScene:
+    async def test_default_append_without_name(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"scene_index": 3, "name": "Scene 3"}
+        )
+
+        result = await create_scene(ctx=mock_context)
+
+        assert isinstance(result, SceneCreatedResult)
+        assert result.scene_index == 3
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.create"
+        assert req.params == {"index": -1}
+
+    async def test_explicit_insert_and_name(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"scene_index": 2, "name": "Bridge"}
+        )
+
+        await create_scene(ctx=mock_context, index=1, name="Bridge")
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.params == {"index": 1, "name": "Bridge"}
+
+
+class TestSceneActions:
+    async def test_delete_scene(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"scene_index": 2})
+
+        result = await delete_scene(ctx=mock_context, scene_index=2)
+
+        assert isinstance(result, SceneDeletedResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.delete"
+        assert req.params == {"scene_index": 2}
+
+    async def test_duplicate_scene(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"source_scene_index": 1, "new_scene_index": 2}
+        )
+
+        result = await duplicate_scene(ctx=mock_context, scene_index=1)
+
+        assert isinstance(result, SceneDuplicatedResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.duplicate"
+        assert req.params == {"scene_index": 1}
+
+    async def test_fire_scene(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"scene_index": 1})
+
+        result = await fire_scene(ctx=mock_context, scene_index=1)
+
+        assert isinstance(result, SceneActionResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.fire"
+        assert req.params == {"scene_index": 1}
+
+    async def test_stop_scene(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"scene_index": 2})
+
+        result = await stop_scene(ctx=mock_context, scene_index=2)
+
+        assert isinstance(result, SceneActionResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.stop"
+        assert req.params == {"scene_index": 2}
+
+    async def test_set_scene_name(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"scene_index": 1, "name": "Outro"}
+        )
+
+        result = await set_scene_name(ctx=mock_context, scene_index=1, name="Outro")
+
+        assert isinstance(result, SceneRenamedResult)
+        assert result.name == "Outro"
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "scene.set_name"
+        assert req.params == {"scene_index": 1, "name": "Outro"}
+
+    async def test_action_raises_remote_not_found(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Scene 9 does not exist",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await delete_scene(ctx=mock_context, scene_index=9)

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -364,11 +364,13 @@ These tools match or exceed the original ahujasid feature set, add arrangement v
 
 These tools add scene management, arrangement view (our key differentiator), sends/returns, recording, and clip properties.
 
-#### Scene Management (5 tools)
+#### Scene Management (7 tools)
 - `get_scenes` — list all scenes with names and indices
 - `create_scene` — create at index
 - `delete_scene` — delete by index
+- `duplicate_scene` — duplicate a scene
 - `fire_scene` — launch scene
+- `stop_scene` — stop the targeted scene row
 - `set_scene_name` — rename scene
 
 #### Arrangement View (5 tools)
@@ -400,7 +402,7 @@ These tools add scene management, arrangement view (our key differentiator), sen
 - `undo` — undo last action
 - `redo` — redo last undone action
 
-**Phase 2 total: 24 tools** (cumulative: 61 tools)
+**Phase 2 total: 26 tools** (cumulative: 63 tools)
 
 ### Phase 3: Advanced
 
@@ -491,6 +493,13 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `set_track_mute` | `track.set_mute` |
 | `set_track_solo` | `track.set_solo` |
 | `set_track_arm` | `track.set_arm` |
+| `get_scenes` | `scene.get_all` |
+| `create_scene` | `scene.create` |
+| `delete_scene` | `scene.delete` |
+| `duplicate_scene` | `scene.duplicate` |
+| `fire_scene` | `scene.fire` |
+| `stop_scene` | `scene.stop` |
+| `set_scene_name` | `scene.set_name` |
 | `create_clip` | `clip.create` |
 | `add_notes_to_clip` | `clip.add_notes` |
 | `get_clip_notes` | `clip.get_notes` |

--- a/remote_script/AbletonLiveMCP/__init__.py
+++ b/remote_script/AbletonLiveMCP/__init__.py
@@ -55,6 +55,7 @@ class AbletonLiveMCP(ControlSurface):
         from .handlers.clip import ClipHandler
         from .handlers.device import DeviceHandler
         from .handlers.mixer import MixerHandler
+        from .handlers.scene import SceneHandler
         from .handlers.session import SessionHandler
         from .handlers.track import TrackHandler
 
@@ -65,6 +66,7 @@ class AbletonLiveMCP(ControlSurface):
         self._dispatcher.register("arrangement", ArrangementHandler(self))
         self._dispatcher.register("browser", BrowserHandler(self))
         self._dispatcher.register("mixer", MixerHandler(self))
+        self._dispatcher.register("scene", SceneHandler(self))
 
     def disconnect(self) -> None:
         """Ableton lifecycle hook -- shut down the TCP server."""

--- a/remote_script/AbletonLiveMCP/handlers/__init__.py
+++ b/remote_script/AbletonLiveMCP/handlers/__init__.py
@@ -9,6 +9,7 @@ from .browser import BrowserHandler
 from .clip import ClipHandler
 from .device import DeviceHandler
 from .mixer import MixerHandler
+from .scene import SceneHandler
 from .session import SessionHandler
 from .track import TrackHandler
 
@@ -18,6 +19,7 @@ __all__ = [
     "ClipHandler",
     "DeviceHandler",
     "MixerHandler",
+    "SceneHandler",
     "SessionHandler",
     "TrackHandler",
 ]

--- a/remote_script/AbletonLiveMCP/handlers/scene.py
+++ b/remote_script/AbletonLiveMCP/handlers/scene.py
@@ -1,0 +1,187 @@
+"""Scene command handlers for the Ableton Live MCP Remote Script."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
+from .base import BaseHandler
+
+
+class SceneHandler(BaseHandler):
+    """Handle scene list, CRUD, and launch/stop commands."""
+
+    def _require_scene_index(self, params: dict[str, Any]) -> int:
+        raw = params.get("scene_index")
+        if raw is None:
+            raise InvalidParamsError("'scene_index' parameter is required")
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise InvalidParamsError("'scene_index' must be an integer")
+        if raw < 1:
+            raise InvalidParamsError("'scene_index' must be at least 1")
+        return raw
+
+    def _resolve_scene(self, params: dict[str, Any]) -> tuple[Any, int, int]:
+        scene_index = self._require_scene_index(params)
+        scenes = self._song.scenes
+        scene_count = len(scenes)
+        if scene_index > scene_count:
+            raise NotFoundError(
+                f"Scene {scene_index} does not exist (song has {scene_count} scene(s))"
+            )
+        lo_index = scene_index - 1
+        return scenes[lo_index], scene_index, lo_index
+
+    def _require_name(
+        self,
+        params: dict[str, Any],
+        *,
+        required: bool,
+    ) -> str | None:
+        name = params.get("name")
+        if name is None:
+            if required:
+                raise InvalidParamsError("'name' parameter is required")
+            return None
+        if not isinstance(name, str):
+            raise InvalidParamsError("'name' must be a string")
+        if not name.strip():
+            raise InvalidParamsError("'name' must not be empty")
+        return name
+
+    def _serialize_scene(self, scene: Any, *, scene_index: int) -> dict[str, Any]:
+        tempo_enabled = bool(scene.tempo_enabled)
+        raw_tempo = float(scene.tempo)
+        tempo = raw_tempo if tempo_enabled and raw_tempo >= 0.0 else None
+
+        time_signature_enabled = bool(scene.time_signature_enabled)
+        raw_numerator = int(scene.time_signature_numerator)
+        raw_denominator = int(scene.time_signature_denominator)
+        numerator = (
+            raw_numerator if time_signature_enabled and raw_numerator >= 0 else None
+        )
+        denominator = (
+            raw_denominator if time_signature_enabled and raw_denominator >= 0 else None
+        )
+
+        return {
+            "scene_index": scene_index,
+            "name": str(scene.name),
+            "is_empty": bool(scene.is_empty),
+            "is_triggered": bool(scene.is_triggered),
+            "tempo_enabled": tempo_enabled,
+            "tempo": tempo,
+            "time_signature_enabled": time_signature_enabled,
+            "time_signature_numerator": numerator,
+            "time_signature_denominator": denominator,
+        }
+
+    def handle_get_all(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return all scenes with their outward API shape."""
+
+        def _read() -> dict[str, Any]:
+            scenes = [
+                self._serialize_scene(scene, scene_index=scene_index)
+                for scene_index, scene in enumerate(self._song.scenes, start=1)
+            ]
+            return {"scenes": scenes}
+
+        return self._run_on_main_thread(_read)
+
+    def handle_create(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Create a scene at the requested Live insertion index."""
+        index = params.get("index", -1)
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise InvalidParamsError("'index' must be an integer")
+        name = self._require_name(params, required=False)
+
+        def _create() -> dict[str, Any]:
+            song = self._song
+            scenes = song.scenes
+            scene_count = len(scenes)
+            if index < -1 or (index != -1 and (index < 0 or index > scene_count - 1)):
+                raise InvalidParamsError(
+                    f"'index' must be -1 (append) or 0..{scene_count - 1}, got {index}"
+                )
+
+            created_scene = song.create_scene(index)
+            new_lo_index = len(song.scenes) - 1 if index == -1 else index
+            new_scene = song.scenes[new_lo_index]
+
+            if created_scene is not None:
+                for candidate_lo_index, candidate_scene in enumerate(song.scenes):
+                    if candidate_scene is created_scene:
+                        new_scene = candidate_scene
+                        new_lo_index = candidate_lo_index
+                        break
+
+            if name is not None:
+                new_scene.name = name
+
+            return {
+                "scene_index": new_lo_index + 1,
+                "name": str(new_scene.name),
+            }
+
+        return self._run_on_main_thread(_create)
+
+    def handle_delete(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Delete a scene by its 1-based index."""
+
+        def _delete() -> dict[str, Any]:
+            _scene, scene_index, lo_index = self._resolve_scene(params)
+            self._song.delete_scene(lo_index)
+            return {"scene_index": scene_index}
+
+        return self._run_on_main_thread(_delete)
+
+    def handle_duplicate(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Duplicate a scene; the copy is inserted immediately after the source."""
+
+        def _duplicate() -> dict[str, Any]:
+            _scene, scene_index, lo_index = self._resolve_scene(params)
+            self._song.duplicate_scene(lo_index)
+            return {
+                "source_scene_index": scene_index,
+                "new_scene_index": scene_index + 1,
+            }
+
+        return self._run_on_main_thread(_duplicate)
+
+    def handle_fire(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Launch a scene."""
+
+        def _fire() -> dict[str, Any]:
+            scene, scene_index, _lo_index = self._resolve_scene(params)
+            scene.fire()
+            return {"scene_index": scene_index}
+
+        return self._run_on_main_thread(_fire)
+
+    def handle_stop(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Stop clip slots in the targeted scene row only."""
+
+        def _stop() -> dict[str, Any]:
+            _scene, scene_index, lo_index = self._resolve_scene(params)
+            for track in self._song.tracks:
+                clip_slots = getattr(track, "clip_slots", ())
+                if lo_index < len(clip_slots):
+                    clip_slots[lo_index].stop()
+            return {"scene_index": scene_index}
+
+        return self._run_on_main_thread(_stop)
+
+    def handle_set_name(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Rename a scene."""
+        name = self._require_name(params, required=True)
+        assert name is not None
+
+        def _set_name() -> dict[str, Any]:
+            scene, scene_index, _lo_index = self._resolve_scene(params)
+            scene.name = name
+            return {"scene_index": scene_index, "name": str(scene.name)}
+
+        return self._run_on_main_thread(_set_name)
+
+
+__all__ = ["SceneHandler"]

--- a/src/mcp_ableton/tools/__init__.py
+++ b/src/mcp_ableton/tools/__init__.py
@@ -5,6 +5,7 @@ import mcp_ableton.tools.browser  # noqa: F401
 import mcp_ableton.tools.clip  # noqa: F401
 import mcp_ableton.tools.device  # noqa: F401
 import mcp_ableton.tools.mixer  # noqa: F401
+import mcp_ableton.tools.scene  # noqa: F401
 import mcp_ableton.tools.session  # noqa: F401
 import mcp_ableton.tools.track  # noqa: F401
 

--- a/src/mcp_ableton/tools/scene.py
+++ b/src/mcp_ableton/tools/scene.py
@@ -1,0 +1,224 @@
+"""MCP tools for Ableton Live scene management."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from mcp.server.fastmcp import Context  # noqa: TCH002
+from pydantic import BaseModel, Field
+
+from mcp_ableton._app import mcp
+from mcp_ableton.protocol import CommandRequest
+
+if TYPE_CHECKING:
+    from mcp_ableton.connection import AbletonConnection
+
+
+SceneIndex = Annotated[
+    int,
+    Field(
+        description="1-based scene index (the first scene is 1).",
+        ge=1,
+    ),
+]
+
+
+class SceneInfo(BaseModel):
+    """Per-scene snapshot returned by ``get_scenes``."""
+
+    scene_index: int
+    name: str
+    is_empty: bool
+    is_triggered: bool
+    tempo_enabled: bool
+    tempo: float | None
+    time_signature_enabled: bool
+    time_signature_numerator: int | None
+    time_signature_denominator: int | None
+
+
+class ScenesResult(BaseModel):
+    """All scenes currently in the song."""
+
+    scenes: list[SceneInfo]
+
+
+class SceneCreatedResult(BaseModel):
+    """Result of ``create_scene``."""
+
+    scene_index: int
+    name: str
+
+
+class SceneDeletedResult(BaseModel):
+    """Result of ``delete_scene``."""
+
+    scene_index: int
+
+
+class SceneDuplicatedResult(BaseModel):
+    """Result of ``duplicate_scene``."""
+
+    source_scene_index: int
+    new_scene_index: int
+
+
+class SceneActionResult(BaseModel):
+    """Result of ``fire_scene`` or ``stop_scene``."""
+
+    scene_index: int
+
+
+class SceneRenamedResult(BaseModel):
+    """Result of ``set_scene_name``."""
+
+    scene_index: int
+    name: str
+
+
+def _get_connection(ctx: Context) -> AbletonConnection:
+    connection: AbletonConnection = ctx.request_context.lifespan_context.connection
+    return connection
+
+
+@mcp.tool()
+async def get_scenes(ctx: Context) -> ScenesResult:
+    """Get all scenes with launch and tempo/time-signature metadata."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(command="scene.get_all")
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ScenesResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def create_scene(
+    ctx: Context,
+    index: Annotated[
+        int,
+        Field(
+            description=(
+                "Insert position using Live's API: -1 appends at the end; "
+                "0..N-1 inserts before that 0-based slot."
+            ),
+            ge=-1,
+        ),
+    ] = -1,
+    name: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional scene name applied after creation (non-empty if set)."
+            ),
+            min_length=1,
+        ),
+    ] = None,
+) -> SceneCreatedResult:
+    """Create a new scene."""
+    connection = _get_connection(ctx)
+    params: dict[str, int | str] = {"index": index}
+    if name is not None:
+        params["name"] = name
+    request = CommandRequest(command="scene.create", params=params)
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneCreatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def delete_scene(
+    ctx: Context,
+    scene_index: SceneIndex,
+) -> SceneDeletedResult:
+    """Delete a scene from the song."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="scene.delete",
+        params={"scene_index": scene_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneDeletedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def duplicate_scene(
+    ctx: Context,
+    scene_index: SceneIndex,
+) -> SceneDuplicatedResult:
+    """Duplicate a scene; the copy is inserted after the source scene."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="scene.duplicate",
+        params={"scene_index": scene_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneDuplicatedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def fire_scene(
+    ctx: Context,
+    scene_index: SceneIndex,
+) -> SceneActionResult:
+    """Launch every clip slot in the scene."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="scene.fire",
+        params={"scene_index": scene_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneActionResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def stop_scene(
+    ctx: Context,
+    scene_index: SceneIndex,
+) -> SceneActionResult:
+    """Stop playback or recording for the targeted scene row only."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="scene.stop",
+        params={"scene_index": scene_index},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneActionResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_scene_name(
+    ctx: Context,
+    scene_index: SceneIndex,
+    name: Annotated[str, Field(description="New scene name.", min_length=1)],
+) -> SceneRenamedResult:
+    """Rename a scene."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="scene.set_name",
+        params={"scene_index": scene_index, "name": name},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SceneRenamedResult.model_validate(response.result)
+
+
+__all__ = [
+    "SceneActionResult",
+    "SceneCreatedResult",
+    "SceneDeletedResult",
+    "SceneDuplicatedResult",
+    "SceneInfo",
+    "SceneRenamedResult",
+    "ScenesResult",
+    "create_scene",
+    "delete_scene",
+    "duplicate_scene",
+    "fire_scene",
+    "get_scenes",
+    "set_scene_name",
+    "stop_scene",
+]


### PR DESCRIPTION
## Summary

Add scene management MCP tools and Remote Script handlers for listing, creating, deleting, duplicating, launching, stopping, and renaming scenes.

## MCP tools

- Add `src/mcp_ableton/tools/scene.py` with typed `SceneInfo`, `ScenesResult`, and action result models.
- Expose `get_scenes`, `create_scene`, `delete_scene`, `duplicate_scene`, `fire_scene`, `stop_scene`, and `set_scene_name`.
- Register the new scene tool module from `src/mcp_ableton/tools/__init__.py`.

## Remote Script

- Add `remote_script/AbletonLiveMCP/handlers/scene.py` and register the `scene` handler category.
- Keep all scene reads and writes on Ableton's main thread.
- Normalize disabled scene tempo and time signature sentinel values to `None` in the outward API.
- Implement `stop_scene` by stopping only the targeted scene row's clip slots rather than calling a global stop-all API.

## Tests

- Add MCP tool coverage in `Tests/tools/test_scene.py` for registration, schema, validation, request construction, and error handling.
- Add Remote Script handler coverage in `Tests/test_scene_handler.py` for serialization, validation, CRUD, fire, row-scoped stop behavior, and dispatcher mapping.
- Extend `Tests/test_integration.py` with a scene payload round-trip over the TCP server.
- Validation run:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification

- Verified via the real stdio MCP server path using `uv run mcp-ableton` with an MCP stdio client while Ableton Live 12.2.5 and the `AbletonLiveMCP` Remote Script were running on `127.0.0.1:9877`.
- `get_session_info` succeeded with tempo `120.0`, signature `4/4`, `track_count=4`, and `is_playing=false`.
- `get_scenes` succeeded with a baseline of `8` scenes; sampled payload included the full normalized scene shape (`tempo=None` and time-signature fields `None` when disabled).
- `create_scene` appended a new blank scene at index `9`, `set_scene_name` renamed it to `Codex Smoke Scene`, and `get_scenes` reflected the rename.
- `duplicate_scene` created scene `10`; on this Live 12.2.5 build the duplicated scene kept the renamed name `Codex Smoke Scene`.
- Created a disposable MIDI track and clip at scene `9`, added one note, then `fire_scene(9)` launched the row; `get_clip_info` reported `is_playing=true`.
- `stop_scene(9)` stopped the same row without a global stop-all shortcut; `get_clip_info` reported `is_playing=false` afterward.
- Deleted the disposable track and both disposable scenes; `get_scenes` returned to the baseline count of `8`.
- Checked `/Users/markfeaver/Library/Preferences/Ableton/Live 12.2.5/Log.txt` after the smoke run; there were no traceback or error lines in the smoke window.

## Docs

- Update the README shipped-surface/status text to include scene management.
- Update ADR-002 scene roadmap and command mapping entries for the `scene.*` namespace.

Closes #13
