### PR TITLE
Add recording MCP tools and Remote Script handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as sends/returns, recording, and undo/redo.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as sends/returns, clip properties, and undo/redo.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -1,1 +1,3 @@
-"""Test package for Ableton MCP."""
+"""Test package for Ableton Live MCP."""
+
+__all__: list[str] = []

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -26,6 +26,13 @@ class _EchoHandler:
     def handle_get_info(self, params):
         return {"tempo": 120.0, "is_playing": False}
 
+    def handle_start_recording(self, params):
+        return {
+            "action": "start_recording",
+            "is_recording": True,
+            "is_playing": True,
+        }
+
 
 class _BrowserHandler:
     def handle_get_tree(self, params):
@@ -208,6 +215,24 @@ class TestFullRoundTrip:
         assert resp.status == "error"
         assert resp.error is not None
         assert resp.error.code == "UNKNOWN_COMMAND"
+
+        await conn.disconnect()
+
+    async def test_recording_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="session.start_recording", id="recording-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "recording-1"
+        assert resp.result == {
+            "action": "start_recording",
+            "is_recording": True,
+            "is_playing": True,
+        }
 
         await conn.disconnect()
 

--- a/Tests/test_session_handler.py
+++ b/Tests/test_session_handler.py
@@ -23,6 +23,8 @@ class _FakeSong:
         signature_denominator: int = 4,
         is_playing: bool = False,
         record_mode: bool = False,
+        overdub: bool = False,
+        can_capture_midi: bool = True,
         song_length: float = 64.0,
         current_song_time: float = 0.0,
     ):
@@ -31,12 +33,25 @@ class _FakeSong:
         self.signature_denominator = signature_denominator
         self.is_playing = is_playing
         self.record_mode = record_mode
+        self.overdub = overdub
+        self.can_capture_midi = can_capture_midi
         self.song_length = song_length
         self.current_song_time = current_song_time
         self.tracks = [MagicMock() for _ in range(3)]
+        self.captured_midi_destinations: list[int] = []
 
-        self.start_playing = MagicMock()
-        self.stop_playing = MagicMock()
+        self.start_playing = MagicMock(side_effect=self._start_playing)
+        self.stop_playing = MagicMock(side_effect=self._stop_playing)
+        self.capture_midi = MagicMock(side_effect=self._capture_midi)
+
+    def _start_playing(self) -> None:
+        self.is_playing = True
+
+    def _stop_playing(self) -> None:
+        self.is_playing = False
+
+    def _capture_midi(self, destination: int) -> None:
+        self.captured_midi_destinations.append(destination)
 
 
 class _FakeControlSurface:
@@ -225,6 +240,113 @@ class TestStopPlayback:
 
 
 # ===================================================================
+# handle_start_recording / handle_stop_recording / handle_set_overdub
+# ===================================================================
+class TestStartRecording:
+    def test_starts_recording_when_playback_must_start(
+        self, handler: SessionHandler, song: _FakeSong
+    ) -> None:
+        result = handler.handle_start_recording({})
+
+        assert result["action"] == "start_recording"
+        assert result["is_recording"] is True
+        assert result["is_playing"] is True
+        assert song.record_mode is True
+        song.start_playing.assert_called_once()
+
+    def test_starts_recording_when_already_playing(self) -> None:
+        song = _FakeSong(is_playing=True, record_mode=False)
+        handler = SessionHandler(_FakeControlSurface(song))
+
+        result = handler.handle_start_recording({})
+
+        assert result["action"] == "start_recording"
+        assert result["is_recording"] is True
+        assert result["is_playing"] is True
+        song.start_playing.assert_not_called()
+
+
+class TestStopRecording:
+    def test_stops_recording_without_stopping_transport(self) -> None:
+        song = _FakeSong(is_playing=True, record_mode=True)
+        handler = SessionHandler(_FakeControlSurface(song))
+
+        result = handler.handle_stop_recording({})
+
+        assert result["action"] == "stop_recording"
+        assert result["is_recording"] is False
+        assert result["is_playing"] is True
+        assert song.record_mode is False
+        song.stop_playing.assert_not_called()
+
+
+class TestSetOverdub:
+    def test_sets_overdub(self, handler: SessionHandler, song: _FakeSong) -> None:
+        result = handler.handle_set_overdub({"overdub": True})
+
+        assert result["overdub"] is True
+        assert song.overdub is True
+
+    def test_rejects_missing_param(self, handler: SessionHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="required"):
+            handler.handle_set_overdub({})
+
+    def test_rejects_non_boolean(self, handler: SessionHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="boolean"):
+            handler.handle_set_overdub({"overdub": "yes"})
+
+
+class TestCaptureMidi:
+    @pytest.mark.parametrize(
+        ("destination", "expected_destination"),
+        [
+            ("auto", 0),
+            ("session", 1),
+            ("arrangement", 2),
+        ],
+    )
+    def test_captures_midi_for_supported_destinations(
+        self,
+        destination: str,
+        expected_destination: int,
+    ) -> None:
+        song = _FakeSong(can_capture_midi=True)
+        handler = SessionHandler(_FakeControlSurface(song))
+
+        result = handler.handle_capture_midi({"destination": destination})
+
+        assert result == {"destination": destination, "captured": True}
+        song.capture_midi.assert_called_once_with(expected_destination)
+        assert song.captured_midi_destinations == [expected_destination]
+
+    def test_defaults_to_auto_destination(self) -> None:
+        song = _FakeSong(can_capture_midi=True)
+        handler = SessionHandler(_FakeControlSurface(song))
+
+        result = handler.handle_capture_midi({})
+
+        assert result == {"destination": "auto", "captured": True}
+        song.capture_midi.assert_called_once_with(0)
+
+    def test_rejects_invalid_destination(self, handler: SessionHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="must be one of"):
+            handler.handle_capture_midi({"destination": "clip"})
+
+    def test_rejects_non_string_destination(self, handler: SessionHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="must be a string"):
+            handler.handle_capture_midi({"destination": 1})
+
+    def test_rejects_when_no_midi_available(self) -> None:
+        song = _FakeSong(can_capture_midi=False)
+        handler = SessionHandler(_FakeControlSurface(song))
+
+        with pytest.raises(InvalidParamsError, match="No MIDI available to capture"):
+            handler.handle_capture_midi({"destination": "auto"})
+
+        song.capture_midi.assert_not_called()
+
+
+# ===================================================================
 # handle_get_playback_position
 # ===================================================================
 class TestGetPlaybackPosition:
@@ -291,6 +413,22 @@ class TestInvalidParamsErrorRouting:
         assert resp["status"] == "error"
         assert resp["error"]["code"] == "INVALID_PARAMS"
         assert "between 20 and 999" in resp["error"]["message"]
+
+    def test_dispatcher_routes_capture_midi_invalid_params(self) -> None:
+        song = _FakeSong(can_capture_midi=False)
+        cs = _FakeControlSurface(song)
+        dispatcher = Dispatcher(cs)
+        dispatcher.register("session", SessionHandler(cs))
+
+        resp = dispatcher.dispatch(
+            "session.capture_midi",
+            {"destination": "auto"},
+            "cap-1",
+        )
+
+        assert resp["status"] == "error"
+        assert resp["error"]["code"] == "INVALID_PARAMS"
+        assert "No MIDI available to capture" in resp["error"]["message"]
 
     def test_dispatcher_routes_internal_error(self, song: _FakeSong) -> None:
         cs = _FakeControlSurface(song)

--- a/Tests/tools/test_session.py
+++ b/Tests/tools/test_session.py
@@ -19,17 +19,24 @@ from pydantic import ValidationError
 from mcp_ableton._app import mcp
 from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
 from mcp_ableton.tools.session import (
+    MidiCaptureResult,
+    OverdubResult,
     PlaybackPosition,
+    RecordingResult,
     SessionInfo,
     TempoResult,
     TimeSignatureResult,
     TransportResult,
+    capture_midi,
     get_playback_position,
     get_session_info,
+    set_overdub,
     set_tempo,
     set_time_signature,
     start_playback,
+    start_recording,
     stop_playback,
+    stop_recording,
 )
 
 # ---------------------------------------------------------------------------
@@ -41,6 +48,10 @@ TOOL_NAMES = [
     "set_time_signature",
     "start_playback",
     "stop_playback",
+    "start_recording",
+    "stop_recording",
+    "capture_midi",
+    "set_overdub",
     "get_playback_position",
 ]
 
@@ -117,6 +128,28 @@ class TestToolContracts:
         required = tool.parameters.get("required", [])
         assert required == []
 
+    def test_start_recording_has_no_required_params(self) -> None:
+        tool = self._get_tool("start_recording")
+        required = tool.parameters.get("required", [])
+        assert required == []
+
+    def test_stop_recording_has_no_required_params(self) -> None:
+        tool = self._get_tool("stop_recording")
+        required = tool.parameters.get("required", [])
+        assert required == []
+
+    def test_capture_midi_schema(self) -> None:
+        tool = self._get_tool("capture_midi")
+        props = tool.parameters["properties"]
+        assert props["destination"]["enum"] == ["auto", "session", "arrangement"]
+        assert props["destination"]["default"] == "auto"
+
+    def test_set_overdub_schema(self) -> None:
+        tool = self._get_tool("set_overdub")
+        props = tool.parameters["properties"]
+        assert props["overdub"]["type"] == "boolean"
+        assert tool.parameters["required"] == ["overdub"]
+
 
 # ===================================================================
 # 2. Input validation tests (schema-level, via arg_model)
@@ -162,6 +195,40 @@ class TestInputValidation:
         args = model(numerator=numerator, denominator=denominator)
         assert args.numerator == numerator
         assert args.denominator == denominator
+
+    @pytest.mark.parametrize("destination", ["clip", "AUTO", "", "foo"])
+    def test_capture_midi_rejects_invalid_destination(self, destination: str) -> None:
+        model = self._arg_model("capture_midi")
+        with pytest.raises(ValidationError):
+            model(destination=destination)
+
+    @pytest.mark.parametrize("destination", ["auto", "session", "arrangement"])
+    def test_capture_midi_accepts_valid_destinations(self, destination: str) -> None:
+        model = self._arg_model("capture_midi")
+        args = model(destination=destination)
+        assert args.destination == destination
+
+    def test_capture_midi_uses_auto_default(self) -> None:
+        model = self._arg_model("capture_midi")
+        args = model()
+        assert args.destination == "auto"
+
+    def test_set_overdub_requires_boolean(self) -> None:
+        model = self._arg_model("set_overdub")
+        with pytest.raises(ValidationError):
+            model()
+
+    @pytest.mark.parametrize("overdub", ["true", 1, 0, None])
+    def test_set_overdub_rejects_non_bool(self, overdub: object) -> None:
+        model = self._arg_model("set_overdub")
+        with pytest.raises(ValidationError):
+            model(overdub=overdub)
+
+    @pytest.mark.parametrize("overdub", [True, False])
+    def test_set_overdub_accepts_bool(self, overdub: bool) -> None:
+        model = self._arg_model("set_overdub")
+        args = model(overdub=overdub)
+        assert args.overdub is overdub
 
 
 # ===================================================================
@@ -382,6 +449,161 @@ class TestGetPlaybackPosition:
             await get_playback_position(ctx=mock_context)
 
 
+class TestStartRecording:
+    async def test_returns_recording_result(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "action": "start_recording",
+                "is_recording": True,
+                "is_playing": True,
+            }
+        )
+
+        result = await start_recording(ctx=mock_context)
+
+        assert isinstance(result, RecordingResult)
+        assert result.action == "start_recording"
+        assert result.is_recording is True
+        assert result.is_playing is True
+
+    async def test_sends_correct_command(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "action": "start_recording",
+                "is_recording": True,
+                "is_playing": True,
+            }
+        )
+
+        await start_recording(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "session.start_recording"
+        assert req.params == {}
+
+    async def test_raises_on_error_response(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response()
+
+        with pytest.raises(CommandError):
+            await start_recording(ctx=mock_context)
+
+
+class TestStopRecording:
+    async def test_returns_recording_result(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "action": "stop_recording",
+                "is_recording": False,
+                "is_playing": True,
+            }
+        )
+
+        result = await stop_recording(ctx=mock_context)
+
+        assert isinstance(result, RecordingResult)
+        assert result.action == "stop_recording"
+        assert result.is_recording is False
+        assert result.is_playing is True
+
+    async def test_sends_correct_command(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {
+                "action": "stop_recording",
+                "is_recording": False,
+                "is_playing": True,
+            }
+        )
+
+        await stop_recording(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "session.stop_recording"
+        assert req.params == {}
+
+
+class TestCaptureMidi:
+    async def test_returns_capture_result(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"destination": "session", "captured": True}
+        )
+
+        result = await capture_midi(ctx=mock_context, destination="session")
+
+        assert isinstance(result, MidiCaptureResult)
+        assert result.destination == "session"
+        assert result.captured is True
+
+    async def test_sends_default_destination(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            {"destination": "auto", "captured": True}
+        )
+
+        await capture_midi(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "session.capture_midi"
+        assert req.params == {"destination": "auto"}
+
+    async def test_raises_invalid_params_on_remote_error(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message="No MIDI available to capture",
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await capture_midi(ctx=mock_context, destination="arrangement")
+
+
+class TestSetOverdub:
+    async def test_returns_overdub_result(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"overdub": True})
+
+        result = await set_overdub(ctx=mock_context, overdub=True)
+
+        assert isinstance(result, OverdubResult)
+        assert result.overdub is True
+
+    async def test_sends_correct_command_and_params(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response({"overdub": False})
+
+        await set_overdub(ctx=mock_context, overdub=False)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "session.set_overdub"
+        assert req.params == {"overdub": False}
+
+    async def test_raises_on_error_response(
+        self, mock_context: MagicMock, mock_connection: AsyncMock
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message="'overdub' must be a boolean",
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await set_overdub(ctx=mock_context, overdub=True)
+
+
 # ===================================================================
 # 4. Response model validation
 # ===================================================================
@@ -395,6 +617,18 @@ class TestResponseModels:
     def test_tempo_result_rejects_missing_tempo(self) -> None:
         with pytest.raises(ValidationError):
             TempoResult.model_validate({})
+
+    def test_recording_result_rejects_missing_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            RecordingResult.model_validate({"action": "start_recording"})
+
+    def test_capture_result_rejects_missing_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            MidiCaptureResult.model_validate({"destination": "auto"})
+
+    def test_overdub_result_rejects_missing_overdub(self) -> None:
+        with pytest.raises(ValidationError):
+            OverdubResult.model_validate({})
 
     def test_playback_position_accepts_valid_data(self) -> None:
         pos = PlaybackPosition.model_validate(

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -483,7 +483,14 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 |----------|---------------------|
 | `get_session_info` | `session.get_info` |
 | `set_tempo` | `session.set_tempo` |
+| `set_time_signature` | `session.set_time_signature` |
 | `start_playback` | `session.start_playback` |
+| `stop_playback` | `session.stop_playback` |
+| `start_recording` | `session.start_recording` |
+| `stop_recording` | `session.stop_recording` |
+| `capture_midi` | `session.capture_midi` |
+| `set_overdub` | `session.set_overdub` |
+| `get_playback_position` | `session.get_playback_position` |
 | `get_track_info` | `track.get_info` |
 | `create_midi_track` | `track.create_midi` |
 | `create_audio_track` | `track.create_audio` |

--- a/remote_script/AbletonLiveMCP/handlers/session.py
+++ b/remote_script/AbletonLiveMCP/handlers/session.py
@@ -1,15 +1,23 @@
-"""Session and transport command handlers for the Ableton Live MCP Remote Script.
+"""Session, transport, and recording command handlers for the Remote Script.
 
-Handles ``session.*`` commands: get_info, set_tempo, set_time_signature,
-start_playback, stop_playback, get_playback_position.
+Handles ``session.*`` commands for song info, transport control, recording,
+and playback position.
 """
 
+import time
 from typing import Any
 
 from ..dispatcher import InvalidParamsError
 from .base import BaseHandler
 
 VALID_DENOMINATORS = frozenset({1, 2, 4, 8, 16, 32})
+STATE_POLL_ATTEMPTS = 40
+STATE_POLL_INTERVAL_SECONDS = 0.05
+CAPTURE_MIDI_DESTINATIONS = {
+    "auto": 0,
+    "session": 1,
+    "arrangement": 2,
+}
 
 
 class SessionHandler(BaseHandler):
@@ -20,6 +28,61 @@ class SessionHandler(BaseHandler):
     ``song.*`` from the TCP worker thread is unsafe and can crash or error
     (especially around project load).
     """
+
+    def _read_recording_state(self) -> dict[str, Any]:
+        """Read current arrangement recording and transport state."""
+
+        def _read() -> dict[str, Any]:
+            song = self._song
+            return {
+                "is_recording": song.record_mode,
+                "is_playing": song.is_playing,
+            }
+
+        return self._run_on_main_thread(_read)
+
+    def _wait_for_recording_state(
+        self,
+        *,
+        action: str,
+        expected_recording: bool,
+        expected_playing: bool | None = None,
+    ) -> dict[str, Any]:
+        """Poll Live until recording state reflects the requested change."""
+        last_state = self._read_recording_state()
+        for _ in range(STATE_POLL_ATTEMPTS):
+            last_state = self._read_recording_state()
+            recording_matches = last_state["is_recording"] is expected_recording
+            playing_matches = (
+                expected_playing is None or last_state["is_playing"] is expected_playing
+            )
+            if recording_matches and playing_matches:
+                return {"action": action, **last_state}
+            time.sleep(STATE_POLL_INTERVAL_SECONDS)
+
+        raise RuntimeError(
+            "Timed out waiting for recording state update: "
+            f"action={action}, expected_recording={expected_recording}, "
+            f"expected_playing={expected_playing}, actual={last_state}"
+        )
+
+    def _wait_for_overdub_state(self, expected_overdub: bool) -> dict[str, Any]:
+        """Poll Live until overdub reflects the requested change."""
+
+        def _read() -> bool:
+            return self._song.overdub
+
+        last_state = self._run_on_main_thread(_read)
+        for _ in range(STATE_POLL_ATTEMPTS):
+            last_state = self._run_on_main_thread(_read)
+            if last_state is expected_overdub:
+                return {"overdub": last_state}
+            time.sleep(STATE_POLL_INTERVAL_SECONDS)
+
+        raise RuntimeError(
+            "Timed out waiting for overdub state update: "
+            f"expected={expected_overdub}, actual={last_state}"
+        )
 
     def handle_get_info(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return current session state."""
@@ -103,6 +166,71 @@ class SessionHandler(BaseHandler):
 
         self._run_on_main_thread(_stop)
         return {"action": "stop", "is_playing": False}
+
+    def handle_start_recording(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Start arrangement recording and ensure transport is running."""
+
+        def _start() -> None:
+            song = self._song
+            song.record_mode = True
+            if not song.is_playing:
+                song.start_playing()
+
+        self._run_on_main_thread(_start)
+        return self._wait_for_recording_state(
+            action="start_recording",
+            expected_recording=True,
+            expected_playing=True,
+        )
+
+    def handle_stop_recording(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Stop arrangement recording without forcing transport stop."""
+
+        def _stop() -> None:
+            song = self._song
+            song.record_mode = False
+
+        self._run_on_main_thread(_stop)
+        return self._wait_for_recording_state(
+            action="stop_recording",
+            expected_recording=False,
+        )
+
+    def handle_set_overdub(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set MIDI arrangement overdub state."""
+        if "overdub" not in params:
+            raise InvalidParamsError("'overdub' parameter is required")
+
+        overdub = params["overdub"]
+        if not isinstance(overdub, bool):
+            raise InvalidParamsError("'overdub' must be a boolean")
+
+        def _set() -> None:
+            self._song.overdub = overdub
+
+        self._run_on_main_thread(_set)
+        return self._wait_for_overdub_state(overdub)
+
+    def handle_capture_midi(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Capture recently played MIDI into Live."""
+        destination = params.get("destination", "auto")
+        if not isinstance(destination, str):
+            raise InvalidParamsError("'destination' must be a string")
+
+        destination_value = CAPTURE_MIDI_DESTINATIONS.get(destination)
+        if destination_value is None:
+            raise InvalidParamsError(
+                "'destination' must be one of: auto, session, arrangement"
+            )
+
+        def _capture() -> dict[str, Any]:
+            song = self._song
+            if not song.can_capture_midi:
+                raise InvalidParamsError("No MIDI available to capture")
+            song.capture_midi(destination_value)
+            return {"destination": destination, "captured": True}
+
+        return self._run_on_main_thread(_capture)
 
     def handle_get_playback_position(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return current playback position with derived bar/beat values."""

--- a/src/mcp_ableton/tools/session.py
+++ b/src/mcp_ableton/tools/session.py
@@ -1,12 +1,12 @@
-"""MCP tools for session and transport control.
+"""MCP tools for session, transport, and recording control.
 
 Provides tools for querying and controlling Ableton Live's session state:
-tempo, time signature, transport (play/stop), and playback position.
+tempo, time signature, transport, recording, and playback position.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from mcp.server.fastmcp import Context  # noqa: TCH002
 from pydantic import BaseModel, Field
@@ -50,6 +50,27 @@ class TransportResult(BaseModel):
     is_playing: bool
 
 
+class RecordingResult(BaseModel):
+    """Result of an arrangement recording action."""
+
+    action: Literal["start_recording", "stop_recording"]
+    is_recording: bool
+    is_playing: bool
+
+
+class MidiCaptureResult(BaseModel):
+    """Result of a MIDI capture action."""
+
+    destination: Literal["auto", "session", "arrangement"]
+    captured: bool
+
+
+class OverdubResult(BaseModel):
+    """Result of an overdub state change."""
+
+    overdub: bool
+
+
 class PlaybackPosition(BaseModel):
     """Current playback position returned by ``get_playback_position``."""
 
@@ -66,6 +87,19 @@ def _get_connection(ctx: Context) -> AbletonConnection:
     return connection
 
 
+async def _send_session_command(
+    ctx: Context,
+    command: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Send a ``session.*`` command and return the result payload."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(command=command, params=params or {})
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return response.result or {}
+
+
 @mcp.tool()
 async def get_session_info(ctx: Context) -> SessionInfo:
     """Get current session information.
@@ -73,11 +107,8 @@ async def get_session_info(ctx: Context) -> SessionInfo:
     Returns tempo, time signature, track count, playback and recording
     state, and total song length.
     """
-    connection = _get_connection(ctx)
-    request = CommandRequest(command="session.get_info")
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return SessionInfo.model_validate(response.result)
+    result = await _send_session_command(ctx, "session.get_info")
+    return SessionInfo.model_validate(result)
 
 
 @mcp.tool()
@@ -86,14 +117,12 @@ async def set_tempo(
     tempo: float = Field(description="Tempo in BPM (20–999)", ge=20.0, le=999.0),
 ) -> TempoResult:
     """Set the song tempo. Tempo must be between 20 and 999 BPM."""
-    connection = _get_connection(ctx)
-    request = CommandRequest(
-        command="session.set_tempo",
-        params={"tempo": tempo},
+    result = await _send_session_command(
+        ctx,
+        "session.set_tempo",
+        {"tempo": tempo},
     )
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return TempoResult.model_validate(response.result)
+    return TempoResult.model_validate(result)
 
 
 @mcp.tool()
@@ -108,34 +137,82 @@ async def set_time_signature(
 
     Denominator must be a power of 2 (1, 2, 4, 8, 16, or 32).
     """
-    connection = _get_connection(ctx)
-    request = CommandRequest(
-        command="session.set_time_signature",
-        params={"numerator": numerator, "denominator": denominator},
+    result = await _send_session_command(
+        ctx,
+        "session.set_time_signature",
+        {"numerator": numerator, "denominator": denominator},
     )
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return TimeSignatureResult.model_validate(response.result)
+    return TimeSignatureResult.model_validate(result)
 
 
 @mcp.tool()
 async def start_playback(ctx: Context) -> TransportResult:
     """Start transport playback in Ableton Live."""
-    connection = _get_connection(ctx)
-    request = CommandRequest(command="session.start_playback")
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return TransportResult.model_validate(response.result)
+    result = await _send_session_command(ctx, "session.start_playback")
+    return TransportResult.model_validate(result)
 
 
 @mcp.tool()
 async def stop_playback(ctx: Context) -> TransportResult:
     """Stop transport playback in Ableton Live."""
-    connection = _get_connection(ctx)
-    request = CommandRequest(command="session.stop_playback")
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return TransportResult.model_validate(response.result)
+    result = await _send_session_command(ctx, "session.stop_playback")
+    return TransportResult.model_validate(result)
+
+
+@mcp.tool()
+async def start_recording(ctx: Context) -> RecordingResult:
+    """Start arrangement recording in Ableton Live."""
+    result = await _send_session_command(ctx, "session.start_recording")
+    return RecordingResult.model_validate(result)
+
+
+@mcp.tool()
+async def stop_recording(ctx: Context) -> RecordingResult:
+    """Stop arrangement recording in Ableton Live."""
+    result = await _send_session_command(ctx, "session.stop_recording")
+    return RecordingResult.model_validate(result)
+
+
+@mcp.tool()
+async def capture_midi(
+    ctx: Context,
+    destination: Annotated[
+        Literal["auto", "session", "arrangement"],
+        Field(
+            description=(
+                "Capture destination: auto chooses Live's default behavior, "
+                "session targets Session View, arrangement targets Arrangement View."
+            ),
+        ),
+    ] = "auto",
+) -> MidiCaptureResult:
+    """Capture recently played MIDI into Ableton Live."""
+    result = await _send_session_command(
+        ctx,
+        "session.capture_midi",
+        {"destination": destination},
+    )
+    return MidiCaptureResult.model_validate(result)
+
+
+@mcp.tool()
+async def set_overdub(
+    ctx: Context,
+    overdub: Annotated[
+        bool,
+        Field(
+            description="Whether overdub is enabled for arrangement MIDI recording.",
+            strict=True,
+        ),
+    ],
+) -> OverdubResult:
+    """Set the song overdub state."""
+    result = await _send_session_command(
+        ctx,
+        "session.set_overdub",
+        {"overdub": overdub},
+    )
+    return OverdubResult.model_validate(result)
 
 
 @mcp.tool()
@@ -145,23 +222,27 @@ async def get_playback_position(ctx: Context) -> PlaybackPosition:
     Returns the position in beats, bar number, beat within the current
     bar, elapsed time in seconds, and whether playback is active.
     """
-    connection = _get_connection(ctx)
-    request = CommandRequest(command="session.get_playback_position")
-    response = await connection.send_command(request)
-    response.raise_on_error()
-    return PlaybackPosition.model_validate(response.result)
+    result = await _send_session_command(ctx, "session.get_playback_position")
+    return PlaybackPosition.model_validate(result)
 
 
 __all__ = [
+    "MidiCaptureResult",
+    "OverdubResult",
     "PlaybackPosition",
+    "RecordingResult",
     "SessionInfo",
     "TempoResult",
     "TimeSignatureResult",
     "TransportResult",
+    "capture_midi",
     "get_playback_position",
     "get_session_info",
+    "set_overdub",
     "set_tempo",
     "set_time_signature",
+    "start_recording",
     "start_playback",
+    "stop_recording",
     "stop_playback",
 ]


### PR DESCRIPTION
## Summary

Add the Phase 2 recording surface from Issue #28 to the existing `session.*` namespace, including typed MCP tools, Remote Script handlers, tests, and roadmap/docs updates.

## MCP tools

- Add `start_recording()` with typed `RecordingResult`
- Add `stop_recording()` with typed `RecordingResult`
- Add `capture_midi(destination="auto")` with typed `MidiCaptureResult` and destination enum validation for `auto | session | arrangement`
- Add `set_overdub(overdub)` with typed `OverdubResult` and strict boolean validation

## Remote Script

- Add `session.start_recording`, `session.stop_recording`, `session.capture_midi`, and `session.set_overdub`
- Keep recording commands in `handlers/session.py` and run all recording reads/writes through `_run_on_main_thread`
- Map capture destinations to Live integers `auto=0`, `session=1`, `arrangement=2`
- Return `INVALID_PARAMS` when `capture_midi` is called with no capturable MIDI
- Poll Live 12.2.5 after recording/overdub writes so returned state reflects the running build rather than stale same-tick property values

## Tests

- Extend `Tests/tools/test_session.py` for registration, schema/defaults, validation, request construction, and success/error handling of all four new tools
- Extend `Tests/test_session_handler.py` for recording success paths, no-stop semantics, overdub, capture destination mapping, and `INVALID_PARAMS` routing
- Extend `Tests/test_integration.py` with a round-trip `session.start_recording` payload case
- Validation run:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification

Environment: Ableton Live 12.2.5, `AbletonLiveMCP` Remote Script active on port 9877, stdio MCP server path exercised via `uv run mcp-ableton` and an MCP stdio client.

- `get_session_info` succeeded before and after the smoke run
- `set_overdub(true)` returned `{overdub: true}` and `set_overdub(false)` returned `{overdub: false}` after restarting Live to load the updated Remote Script
- `start_recording` returned `{action: "start_recording", is_recording: true, is_playing: true}` and a follow-up `get_session_info` confirmed `is_recording=true` / `is_playing=true`
- `stop_recording` returned `{action: "stop_recording", is_recording: false, is_playing: true}` and a follow-up `get_session_info` confirmed recording cleared without stop-playback semantics; cleanup then used `stop_playback`
- `capture_midi(destination="auto")` returned the expected structured `INVALID_PARAMS` path: `No MIDI available to capture`
- Appended Ableton `Log.txt` lines after the smoke run showed only client connect/disconnect entries; no new Python traceback/error lines were introduced

## Docs

- Update README status text to include recording in the shipped tool surface
- Update ADR-002 command mapping table with `start_recording`, `stop_recording`, `capture_midi`, and `set_overdub`

Closes #28
