### PR TITLE
Add send and return-track mixer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **basic mixer** tools are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **mixer tools including sends/returns and return-track control** are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and basic mixer control. Remaining work focuses on the rest of the roadmap such as sends/returns, clip properties, and undo/redo.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and mixer control for track volume/pan, sends, return tracks, and master volume. Remaining work focuses on the rest of the roadmap such as clip properties, broader return/master addressing, and undo/redo.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -100,6 +100,25 @@ class _MixerHandler:
             "pan": 0.0,
         }
 
+    def handle_get_return_tracks(self, params):
+        return {
+            "return_tracks": [
+                {
+                    "return_index": 1,
+                    "name": "A Return",
+                    "volume": 0.61,
+                    "pan": -0.15,
+                }
+            ]
+        }
+
+    def handle_set_send_level(self, params):
+        return {
+            "track_index": params["track_index"],
+            "send_index": params["send_index"],
+            "level": params["level"],
+        }
+
 
 class _ArrangementHandler:
     def handle_get_clips(self, params):
@@ -315,6 +334,52 @@ class TestFullRoundTrip:
             "name": "Master",
             "volume": 0.88,
             "pan": 0.0,
+        }
+
+        await conn.disconnect()
+
+    async def test_return_tracks_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(command="mixer.get_return_tracks", id="mixer-returns-1")
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "mixer-returns-1"
+        assert resp.result is not None
+        assert resp.result == {
+            "return_tracks": [
+                {
+                    "return_index": 1,
+                    "name": "A Return",
+                    "volume": 0.61,
+                    "pan": -0.15,
+                }
+            ]
+        }
+
+        await conn.disconnect()
+
+    async def test_set_send_level_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(
+            command="mixer.set_send_level",
+            params={"track_index": 2, "send_index": 1, "level": 0.37},
+            id="mixer-send-1",
+        )
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "mixer-send-1"
+        assert resp.result == {
+            "track_index": 2,
+            "send_index": 1,
+            "level": 0.37,
         }
 
         await conn.disconnect()

--- a/Tests/test_mixer_handler.py
+++ b/Tests/test_mixer_handler.py
@@ -10,22 +10,39 @@ from AbletonLiveMCP.handlers.mixer import MixerHandler
 
 
 class _MixerDevice:
-    def __init__(self, volume: float = 0.8, pan: float = 0.1) -> None:
+    def __init__(
+        self,
+        volume: float = 0.8,
+        pan: float = 0.1,
+        sends: list[float] | None = None,
+    ) -> None:
         self.volume = MagicMock(value=volume)
         self.panning = MagicMock(value=pan)
+        self.sends = [MagicMock(value=value) for value in sends or []]
 
 
 class _Track:
-    def __init__(self, name: str, *, volume: float = 0.8, pan: float = 0.1) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        volume: float = 0.8,
+        pan: float = 0.1,
+        sends: list[float] | None = None,
+    ) -> None:
         self.name = name
-        self.mixer_device = _MixerDevice(volume=volume, pan=pan)
+        self.mixer_device = _MixerDevice(volume=volume, pan=pan, sends=sends)
 
 
 class _Song:
     def __init__(self) -> None:
         self.tracks = [
-            _Track("Track 1", volume=0.82, pan=0.15),
-            _Track("Track 2", volume=0.63, pan=-0.35),
+            _Track("Track 1", volume=0.82, pan=0.15, sends=[0.2, 0.4]),
+            _Track("Track 2", volume=0.63, pan=-0.35, sends=[0.1, 0.3]),
+        ]
+        self.return_tracks = [
+            _Track("A Return", volume=0.55, pan=-0.2),
+            _Track("B Return", volume=0.48, pan=0.25),
         ]
         self.master_track = _Track("Master", volume=0.9, pan=0.0)
 
@@ -92,6 +109,58 @@ class TestSetTrackPan:
             handler.handle_set_track_pan({"track_index": 1, "pan": -1.5})
 
 
+class TestGetReturnTracks:
+    def test_serialization_shape(self, handler: MixerHandler) -> None:
+        result = handler.handle_get_return_tracks({})
+
+        assert result == {
+            "return_tracks": [
+                {
+                    "return_index": 1,
+                    "name": "A Return",
+                    "volume": 0.55,
+                    "pan": -0.2,
+                },
+                {
+                    "return_index": 2,
+                    "name": "B Return",
+                    "volume": 0.48,
+                    "pan": 0.25,
+                },
+            ]
+        }
+
+
+class TestSetSendLevel:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_send_level(
+            {"track_index": 2, "send_index": 1, "level": 0.45}
+        )
+
+        assert result == {"track_index": 2, "send_index": 1, "level": 0.45}
+        assert song.tracks[1].mixer_device.sends[0].value == 0.45
+
+    def test_missing_send_returns_not_found(self, handler: MixerHandler) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface())
+        dispatcher.register("mixer", handler)
+
+        response = dispatcher.dispatch(
+            "mixer.set_send_level",
+            {"track_index": 1, "send_index": 9, "level": 0.5},
+            "mix-send-missing",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+        assert "Send 9" in response["error"]["message"]
+
+    def test_out_of_range_level(self, handler: MixerHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="level"):
+            handler.handle_set_send_level(
+                {"track_index": 1, "send_index": 1, "level": 1.1}
+            )
+
+
 class TestGetMasterInfo:
     def test_serialization_shape(self, handler: MixerHandler) -> None:
         result = handler.handle_get_master_info({})
@@ -111,6 +180,44 @@ class TestSetMasterVolume:
         assert song.master_track.mixer_device.volume.value == 0.72
 
 
+class TestSetReturnVolume:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_return_volume({"return_index": 1, "volume": 0.67})
+
+        assert result == {"return_index": 1, "volume": 0.67}
+        assert song.return_tracks[0].mixer_device.volume.value == 0.67
+
+    def test_missing_return_track_returns_not_found(self, song: _Song) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface(song))
+        dispatcher.register("mixer", MixerHandler(_FakeControlSurface(song)))
+
+        response = dispatcher.dispatch(
+            "mixer.set_return_volume",
+            {"return_index": 99, "volume": 0.5},
+            "mix-return-missing",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "NOT_FOUND"
+        assert "Return track 99" in response["error"]["message"]
+
+    def test_out_of_range_volume(self, handler: MixerHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="volume"):
+            handler.handle_set_return_volume({"return_index": 1, "volume": -0.1})
+
+
+class TestSetReturnPan:
+    def test_success(self, handler: MixerHandler, song: _Song) -> None:
+        result = handler.handle_set_return_pan({"return_index": 2, "pan": -0.6})
+
+        assert result == {"return_index": 2, "pan": -0.6}
+        assert song.return_tracks[1].mixer_device.panning.value == -0.6
+
+    def test_out_of_range_pan(self, handler: MixerHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="pan"):
+            handler.handle_set_return_pan({"return_index": 1, "pan": 1.2})
+
+
 class TestDispatcherRegistration:
     def test_dispatcher_routes_mixer_commands(self, song: _Song) -> None:
         dispatcher = Dispatcher(_FakeControlSurface(song))
@@ -124,3 +231,17 @@ class TestDispatcherRegistration:
             "volume": 0.9,
             "pan": 0.0,
         }
+
+    def test_dispatcher_routes_invalid_params_for_send_level(self, song: _Song) -> None:
+        dispatcher = Dispatcher(_FakeControlSurface(song))
+        dispatcher.register("mixer", MixerHandler(_FakeControlSurface(song)))
+
+        response = dispatcher.dispatch(
+            "mixer.set_send_level",
+            {"track_index": 1, "send_index": "bad", "level": 0.4},
+            "mix-invalid-send",
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "INVALID_PARAMS"
+        assert "send_index" in response["error"]["message"]

--- a/Tests/tools/test_mixer.py
+++ b/Tests/tools/test_mixer.py
@@ -15,10 +15,19 @@ from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
 from mcp_ableton.tools.mixer import (
     MasterTrackInfo,
     MasterVolumeSetResult,
+    ReturnPanSetResult,
+    ReturnTrackInfo,
+    ReturnTracksResult,
+    ReturnVolumeSetResult,
+    SendLevelSetResult,
     TrackPanSetResult,
     TrackVolumeSetResult,
     get_master_info,
+    get_return_tracks,
     set_master_volume,
+    set_return_pan,
+    set_return_volume,
+    set_send_level,
     set_track_pan,
     set_track_volume,
 )
@@ -26,14 +35,35 @@ from mcp_ableton.tools.mixer import (
 TOOL_NAMES = [
     "set_track_volume",
     "set_track_pan",
+    "get_return_tracks",
+    "set_send_level",
     "get_master_info",
     "set_master_volume",
+    "set_return_volume",
+    "set_return_pan",
 ]
 
 MASTER_INFO_RESULT = {
     "name": "Master",
     "volume": 0.74,
     "pan": 0.0,
+}
+
+RETURN_TRACKS_RESULT = {
+    "return_tracks": [
+        {
+            "return_index": 1,
+            "name": "A Return",
+            "volume": 0.61,
+            "pan": -0.2,
+        },
+        {
+            "return_index": 2,
+            "name": "B Return",
+            "volume": 0.49,
+            "pan": 0.15,
+        },
+    ]
 }
 
 TRACK_VOLUME_RESULT = {
@@ -46,8 +76,24 @@ TRACK_PAN_RESULT = {
     "pan": -0.25,
 }
 
+SEND_LEVEL_RESULT = {
+    "track_index": 2,
+    "send_index": 1,
+    "level": 0.33,
+}
+
 MASTER_VOLUME_RESULT = {
     "volume": 0.8,
+}
+
+RETURN_VOLUME_RESULT = {
+    "return_index": 1,
+    "volume": 0.64,
+}
+
+RETURN_PAN_RESULT = {
+    "return_index": 1,
+    "pan": -0.45,
 }
 
 
@@ -96,11 +142,38 @@ class TestToolContracts:
         assert props["pan"]["minimum"] == -1.0
         assert props["pan"]["maximum"] == 1.0
 
+    def test_get_return_tracks_schema(self) -> None:
+        tool = self._get_tool("get_return_tracks")
+        assert tool.parameters["properties"] == {}
+        assert "required" not in tool.parameters
+
+    def test_set_send_level_schema(self) -> None:
+        tool = self._get_tool("set_send_level")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["send_index"]["minimum"] == 1
+        assert props["level"]["minimum"] == 0.0
+        assert props["level"]["maximum"] == 1.0
+
     def test_set_master_volume_schema(self) -> None:
         tool = self._get_tool("set_master_volume")
         props = tool.parameters["properties"]
         assert props["volume"]["minimum"] == 0.0
         assert props["volume"]["maximum"] == 1.0
+
+    def test_set_return_volume_schema(self) -> None:
+        tool = self._get_tool("set_return_volume")
+        props = tool.parameters["properties"]
+        assert props["return_index"]["minimum"] == 1
+        assert props["volume"]["minimum"] == 0.0
+        assert props["volume"]["maximum"] == 1.0
+
+    def test_set_return_pan_schema(self) -> None:
+        tool = self._get_tool("set_return_pan")
+        props = tool.parameters["properties"]
+        assert props["return_index"]["minimum"] == 1
+        assert props["pan"]["minimum"] == -1.0
+        assert props["pan"]["maximum"] == 1.0
 
 
 class TestInputValidation:
@@ -124,10 +197,38 @@ class TestInputValidation:
         with pytest.raises(ValidationError):
             model(track_index=1, pan=pan)
 
+    def test_set_send_level_rejects_non_positive_send_index(self) -> None:
+        model = self._arg_model("set_send_level")
+        with pytest.raises(ValidationError):
+            model(track_index=1, send_index=0, level=0.5)
+
+    @pytest.mark.parametrize("level", [-0.1, 1.1])
+    def test_set_send_level_rejects_out_of_range_level(self, level: float) -> None:
+        model = self._arg_model("set_send_level")
+        with pytest.raises(ValidationError):
+            model(track_index=1, send_index=1, level=level)
+
     def test_set_master_volume_accepts_upper_bound(self) -> None:
         model = self._arg_model("set_master_volume")
         args = model(volume=1.0)
         assert args.volume == 1.0
+
+    def test_set_return_volume_rejects_non_positive_return_index(self) -> None:
+        model = self._arg_model("set_return_volume")
+        with pytest.raises(ValidationError):
+            model(return_index=0, volume=0.5)
+
+    @pytest.mark.parametrize("volume", [-0.1, 1.1])
+    def test_set_return_volume_rejects_out_of_range_volume(self, volume: float) -> None:
+        model = self._arg_model("set_return_volume")
+        with pytest.raises(ValidationError):
+            model(return_index=1, volume=volume)
+
+    @pytest.mark.parametrize("pan", [-1.1, 1.1])
+    def test_set_return_pan_rejects_out_of_range_pan(self, pan: float) -> None:
+        model = self._arg_model("set_return_pan")
+        with pytest.raises(ValidationError):
+            model(return_index=1, pan=pan)
 
 
 class TestSetTrackVolume:
@@ -228,6 +329,103 @@ class TestGetMasterInfo:
         assert req.params == {}
 
 
+class TestGetReturnTracks:
+    async def test_returns_return_tracks(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_TRACKS_RESULT)
+
+        result = await get_return_tracks(ctx=mock_context)
+
+        assert isinstance(result, ReturnTracksResult)
+        assert result.return_tracks == [
+            ReturnTrackInfo(
+                return_index=1,
+                name="A Return",
+                volume=0.61,
+                pan=-0.2,
+            ),
+            ReturnTrackInfo(
+                return_index=2,
+                name="B Return",
+                volume=0.49,
+                pan=0.15,
+            ),
+        ]
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_TRACKS_RESULT)
+
+        await get_return_tracks(ctx=mock_context)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.get_return_tracks"
+        assert req.params == {}
+
+
+class TestSetSendLevel:
+    async def test_returns_send_level_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(SEND_LEVEL_RESULT)
+
+        result = await set_send_level(
+            ctx=mock_context,
+            track_index=2,
+            send_index=1,
+            level=0.33,
+        )
+
+        assert isinstance(result, SendLevelSetResult)
+        assert result.track_index == 2
+        assert result.send_index == 1
+        assert result.level == 0.33
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(SEND_LEVEL_RESULT)
+
+        await set_send_level(
+            ctx=mock_context,
+            track_index=3,
+            send_index=2,
+            level=0.75,
+        )
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_send_level"
+        assert req.params == {"track_index": 3, "send_index": 2, "level": 0.75}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Send 4 does not exist for track 1",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await set_send_level(
+                ctx=mock_context,
+                track_index=1,
+                send_index=4,
+                level=0.5,
+            )
+
+
 class TestSetMasterVolume:
     async def test_returns_master_volume_result(
         self,
@@ -266,3 +464,85 @@ class TestSetMasterVolume:
 
         with pytest.raises(CommandError, match="INVALID_PARAMS"):
             await set_master_volume(ctx=mock_context, volume=0.9)
+
+
+class TestSetReturnVolume:
+    async def test_returns_return_volume_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_VOLUME_RESULT)
+
+        result = await set_return_volume(ctx=mock_context, return_index=1, volume=0.64)
+
+        assert isinstance(result, ReturnVolumeSetResult)
+        assert result.return_index == 1
+        assert result.volume == 0.64
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_VOLUME_RESULT)
+
+        await set_return_volume(ctx=mock_context, return_index=2, volume=0.27)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_return_volume"
+        assert req.params == {"return_index": 2, "volume": 0.27}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Return track 9 does not exist",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await set_return_volume(ctx=mock_context, return_index=9, volume=0.5)
+
+
+class TestSetReturnPan:
+    async def test_returns_return_pan_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_PAN_RESULT)
+
+        result = await set_return_pan(ctx=mock_context, return_index=1, pan=-0.45)
+
+        assert isinstance(result, ReturnPanSetResult)
+        assert result.return_index == 1
+        assert result.pan == -0.45
+
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(RETURN_PAN_RESULT)
+
+        await set_return_pan(ctx=mock_context, return_index=2, pan=0.35)
+
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "mixer.set_return_pan"
+        assert req.params == {"return_index": 2, "pan": 0.35}
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="INVALID_PARAMS",
+            message="'pan' must be between -1.0 and 1.0, got 1.5",
+        )
+
+        with pytest.raises(CommandError, match="INVALID_PARAMS"):
+            await set_return_pan(ctx=mock_context, return_index=1, pan=0.5)

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -524,8 +524,12 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `search_browser` | `browser.search` |
 | `set_track_volume` | `mixer.set_track_volume` |
 | `set_track_pan` | `mixer.set_track_pan` |
+| `get_return_tracks` | `mixer.get_return_tracks` |
+| `set_send_level` | `mixer.set_send_level` |
 | `get_master_info` | `mixer.get_master_info` |
 | `set_master_volume` | `mixer.set_master_volume` |
+| `set_return_volume` | `mixer.set_return_volume` |
+| `set_return_pan` | `mixer.set_return_pan` |
 
 ### Threading model (same as competitors, proven pattern)
 

--- a/remote_script/AbletonLiveMCP/handlers/mixer.py
+++ b/remote_script/AbletonLiveMCP/handlers/mixer.py
@@ -11,16 +11,28 @@ from .base import BaseHandler
 class MixerHandler(BaseHandler):
     """Handle per-track and master mixer commands."""
 
+    def _require_positive_int_param(self, params: dict[str, Any], name: str) -> int:
+        """Return a validated 1-based integer parameter."""
+        value = params.get(name)
+        if value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise InvalidParamsError(f"'{name}' must be an integer")
+        if value < 1:
+            raise InvalidParamsError(f"'{name}' must be at least 1")
+        return value
+
     def _require_track_index(self, params: dict[str, Any]) -> int:
         """Return a validated 1-based track index."""
-        track_index = params.get("track_index")
-        if track_index is None:
-            raise InvalidParamsError("'track_index' parameter is required")
-        if isinstance(track_index, bool) or not isinstance(track_index, int):
-            raise InvalidParamsError("'track_index' must be an integer")
-        if track_index < 1:
-            raise InvalidParamsError("'track_index' must be at least 1")
-        return track_index
+        return self._require_positive_int_param(params, "track_index")
+
+    def _require_send_index(self, params: dict[str, Any]) -> int:
+        """Return a validated 1-based send index."""
+        return self._require_positive_int_param(params, "send_index")
+
+    def _require_return_index(self, params: dict[str, Any]) -> int:
+        """Return a validated 1-based return track index."""
+        return self._require_positive_int_param(params, "return_index")
 
     def _require_float_range(
         self,
@@ -53,6 +65,29 @@ class MixerHandler(BaseHandler):
                 f"Track {track_index} does not exist (song has {track_count} track(s))"
             )
         return tracks[track_index - 1]
+
+    def _resolve_return_track(self, return_index: int) -> Any:
+        """Resolve a 1-based return track index."""
+        return_tracks = self._song.return_tracks
+        return_count = len(return_tracks)
+        if return_index > return_count:
+            raise NotFoundError(
+                "Return track "
+                f"{return_index} does not exist "
+                f"(song has {return_count} return track(s))"
+            )
+        return return_tracks[return_index - 1]
+
+    def _resolve_send(self, track: Any, track_index: int, send_index: int) -> Any:
+        """Resolve a 1-based send index on a normal track."""
+        sends = track.mixer_device.sends
+        send_count = len(sends)
+        if send_index > send_count:
+            raise NotFoundError(
+                f"Send {send_index} does not exist for track {track_index} "
+                f"(track has {send_count} send(s))"
+            )
+        return sends[send_index - 1]
 
     def handle_set_track_volume(self, params: dict[str, Any]) -> dict[str, Any]:
         """Set a normal track's volume."""
@@ -94,6 +129,46 @@ class MixerHandler(BaseHandler):
 
         return self._run_on_main_thread(_write)
 
+    def handle_get_return_tracks(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return all return tracks with volume and pan metadata."""
+
+        def _read() -> dict[str, Any]:
+            return_tracks = [
+                {
+                    "return_index": index,
+                    "name": str(getattr(return_track, "name", "")),
+                    "volume": float(return_track.mixer_device.volume.value),
+                    "pan": float(return_track.mixer_device.panning.value),
+                }
+                for index, return_track in enumerate(self._song.return_tracks, start=1)
+            ]
+            return {"return_tracks": return_tracks}
+
+        return self._run_on_main_thread(_read)
+
+    def handle_set_send_level(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set a send level on a normal track."""
+        track_index = self._require_track_index(params)
+        send_index = self._require_send_index(params)
+        level = self._require_float_range(
+            params,
+            "level",
+            minimum=0.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            track = self._resolve_track(track_index)
+            send = self._resolve_send(track, track_index, send_index)
+            send.value = level
+            return {
+                "track_index": track_index,
+                "send_index": send_index,
+                "level": float(send.value),
+            }
+
+        return self._run_on_main_thread(_write)
+
     def handle_get_master_info(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return the master track name and mixer state."""
 
@@ -121,6 +196,46 @@ class MixerHandler(BaseHandler):
             mixer = self._song.master_track.mixer_device
             mixer.volume.value = volume
             return {"volume": float(mixer.volume.value)}
+
+        return self._run_on_main_thread(_write)
+
+    def handle_set_return_volume(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set a return track volume."""
+        return_index = self._require_return_index(params)
+        volume = self._require_float_range(
+            params,
+            "volume",
+            minimum=0.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            return_track = self._resolve_return_track(return_index)
+            return_track.mixer_device.volume.value = volume
+            return {
+                "return_index": return_index,
+                "volume": float(return_track.mixer_device.volume.value),
+            }
+
+        return self._run_on_main_thread(_write)
+
+    def handle_set_return_pan(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set a return track pan."""
+        return_index = self._require_return_index(params)
+        pan = self._require_float_range(
+            params,
+            "pan",
+            minimum=-1.0,
+            maximum=1.0,
+        )
+
+        def _write() -> dict[str, Any]:
+            return_track = self._resolve_return_track(return_index)
+            return_track.mixer_device.panning.value = pan
+            return {
+                "return_index": return_index,
+                "pan": float(return_track.mixer_device.panning.value),
+            }
 
         return self._run_on_main_thread(_write)
 

--- a/src/mcp_ableton/tools/mixer.py
+++ b/src/mcp_ableton/tools/mixer.py
@@ -14,12 +14,52 @@ if TYPE_CHECKING:
     from mcp_ableton.connection import AbletonConnection
 
 
+TrackIndex = Annotated[
+    int,
+    Field(
+        description="1-based track index.",
+        ge=1,
+    ),
+]
+
+SendIndex = Annotated[
+    int,
+    Field(
+        description="1-based send index on the track.",
+        ge=1,
+    ),
+]
+
+ReturnIndex = Annotated[
+    int,
+    Field(
+        description="1-based return track index.",
+        ge=1,
+    ),
+]
+
+
 class MasterTrackInfo(BaseModel):
     """Snapshot of the master track mixer state."""
 
     name: str
     volume: float
     pan: float
+
+
+class ReturnTrackInfo(BaseModel):
+    """Snapshot of a return track mixer state."""
+
+    return_index: int
+    name: str
+    volume: float
+    pan: float
+
+
+class ReturnTracksResult(BaseModel):
+    """All return tracks currently in the song."""
+
+    return_tracks: list[ReturnTrackInfo]
 
 
 class TrackVolumeSetResult(BaseModel):
@@ -36,10 +76,32 @@ class TrackPanSetResult(BaseModel):
     pan: float
 
 
+class SendLevelSetResult(BaseModel):
+    """Result of ``set_send_level``."""
+
+    track_index: int
+    send_index: int
+    level: float
+
+
 class MasterVolumeSetResult(BaseModel):
     """Result of ``set_master_volume``."""
 
     volume: float
+
+
+class ReturnVolumeSetResult(BaseModel):
+    """Result of ``set_return_volume``."""
+
+    return_index: int
+    volume: float
+
+
+class ReturnPanSetResult(BaseModel):
+    """Result of ``set_return_pan``."""
+
+    return_index: int
+    pan: float
 
 
 def _get_connection(ctx: Context) -> AbletonConnection:
@@ -51,13 +113,7 @@ def _get_connection(ctx: Context) -> AbletonConnection:
 @mcp.tool()
 async def set_track_volume(
     ctx: Context,
-    track_index: Annotated[
-        int,
-        Field(
-            description="1-based track index.",
-            ge=1,
-        ),
-    ],
+    track_index: TrackIndex,
     volume: Annotated[
         float,
         Field(
@@ -81,13 +137,7 @@ async def set_track_volume(
 @mcp.tool()
 async def set_track_pan(
     ctx: Context,
-    track_index: Annotated[
-        int,
-        Field(
-            description="1-based track index.",
-            ge=1,
-        ),
-    ],
+    track_index: TrackIndex,
     pan: Annotated[
         float,
         Field(
@@ -106,6 +156,45 @@ async def set_track_pan(
     response = await connection.send_command(request)
     response.raise_on_error()
     return TrackPanSetResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_return_tracks(ctx: Context) -> ReturnTracksResult:
+    """Get all return tracks with volume and pan metadata."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(command="mixer.get_return_tracks")
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ReturnTracksResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_send_level(
+    ctx: Context,
+    track_index: TrackIndex,
+    send_index: SendIndex,
+    level: Annotated[
+        float,
+        Field(
+            description="Send level value normalized to 0.0-1.0.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ],
+) -> SendLevelSetResult:
+    """Set a send level on a normal track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_send_level",
+        params={
+            "track_index": track_index,
+            "send_index": send_index,
+            "level": level,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SendLevelSetResult.model_validate(response.result)
 
 
 @mcp.tool()
@@ -141,13 +230,70 @@ async def set_master_volume(
     return MasterVolumeSetResult.model_validate(response.result)
 
 
+@mcp.tool()
+async def set_return_volume(
+    ctx: Context,
+    return_index: ReturnIndex,
+    volume: Annotated[
+        float,
+        Field(
+            description="Return track volume value normalized to 0.0-1.0.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ],
+) -> ReturnVolumeSetResult:
+    """Set a return track's volume."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_return_volume",
+        params={"return_index": return_index, "volume": volume},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ReturnVolumeSetResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_return_pan(
+    ctx: Context,
+    return_index: ReturnIndex,
+    pan: Annotated[
+        float,
+        Field(
+            description="Return track pan from -1.0 (left) to 1.0 (right).",
+            ge=-1.0,
+            le=1.0,
+        ),
+    ],
+) -> ReturnPanSetResult:
+    """Set a return track's pan."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="mixer.set_return_pan",
+        params={"return_index": return_index, "pan": pan},
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ReturnPanSetResult.model_validate(response.result)
+
+
 __all__ = [
     "MasterTrackInfo",
     "MasterVolumeSetResult",
+    "ReturnPanSetResult",
+    "ReturnTrackInfo",
+    "ReturnTracksResult",
+    "ReturnVolumeSetResult",
+    "SendLevelSetResult",
     "TrackPanSetResult",
     "TrackVolumeSetResult",
     "get_master_info",
+    "get_return_tracks",
     "set_master_volume",
+    "set_return_pan",
+    "set_return_volume",
+    "set_send_level",
     "set_track_pan",
     "set_track_volume",
 ]


### PR DESCRIPTION
## Summary
- add mixer MCP tools for return-track reads plus send/return write operations in the existing `mixer.py` module
- extend the Remote Script mixer handler with dedicated return/send resolution and error handling
- update mixer docs/status text for the newly shipped sends/returns surface

## MCP tools
- add `get_return_tracks()` returning typed `ReturnTrackInfo` / `ReturnTracksResult`
- add `set_send_level(track_index, send_index, level)` with 1-based track/send indexing and normalized `level` validation
- add `set_return_volume(return_index, volume)` with dedicated 1-based return indexing
- add `set_return_pan(return_index, pan)` with dedicated 1-based return indexing

## Remote Script
- add `mixer.get_return_tracks`, `mixer.set_send_level`, `mixer.set_return_volume`, and `mixer.set_return_pan`
- keep all reads/writes on Ableton's main thread via `_run_on_main_thread`
- add dedicated helpers for positive integer params, return-track lookup, and send lookup
- return `NOT_FOUND` for missing tracks/returns/sends and `INVALID_PARAMS` for bad types or out-of-range numeric values

## Tests
- extend `Tests/tools/test_mixer.py` for registration, descriptions, schema constraints, validation, command construction, and success/error handling
- extend `Tests/test_mixer_handler.py` for return-track serialization, send/return success paths, `NOT_FOUND`, and `INVALID_PARAMS`
- extend `Tests/test_integration.py` with round-trip mixer payload coverage for return tracks and send levels
- run `uv run ruff check .`
- run `uv run ruff format --check .`
- run `uv run mypy src/`
- run `uv run pytest`

## Manual verification
- smoke path used the real stdio MCP server via `uv run mcp-ableton` against Ableton Live 12.2.5 with the `AbletonLiveMCP` Remote Script active on `127.0.0.1:9877`
- `get_session_info` succeeded on the default disposable Live set (`track_count=4`, `tempo=120.0`, `song_length=232.0`)
- `get_return_tracks` returned two return tracks: `A-Reverb` and `B-Delay`
- `set_send_level(track_index=1, send_index=1, level=0.17)` succeeded on the disposable default set and returned `level=0.17000000178813934`
- `set_return_volume(return_index=1, volume=0.33)` succeeded, follow-up `get_return_tracks` showed `A-Reverb.volume=0.33000001311302185`, then restored to `0.8500000238418579`
- `set_return_pan(return_index=1, pan=0.25)` succeeded, follow-up `get_return_tracks` showed `A-Reverb.pan=0.25`, then restored to `0.0`
- explicit `NOT_FOUND` verified with `set_send_level(track_index=1, send_index=99, level=0.5)` returning `Send 99 does not exist for track 1 (track has 2 send(s))`
- checked `~/Library/Preferences/Ableton/Live 12.2.5/Log.txt` after the smoke run; no Python traceback or unexpected error lines were added

## Docs
- update the README status text to reflect shipped sends/returns support
- extend ADR 002's command mapping table with the new mixer commands

Closes #16
