### PR TITLE
Add clip properties and automation MCP tools and handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **mixer tools including sends/returns and return-track control** are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **clip properties and clip automation**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **mixer tools including sends/returns and return-track control** are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, MIDI notes, arrangement clips, browser navigation, device parameters, and mixer control for track volume/pan, sends, return tracks, and master volume. Remaining work focuses on the rest of the roadmap such as clip properties, broader return/master addressing, and undo/redo.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, clip loop/color editing, clip automation read/write, MIDI notes, arrangement clips, browser navigation, device parameters, and mixer control for track volume/pan, sends, return tracks, and master volume. Remaining work focuses on the rest of the roadmap such as broader return/master addressing and undo/redo.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 

--- a/Tests/test_clip_handler.py
+++ b/Tests/test_clip_handler.py
@@ -48,10 +48,15 @@ class _Clip:
         self.length = length
         self.is_audio_clip = audio
         self.is_midi_clip = not audio
+        self.loop_start = 0.0
+        self.loop_end = length
+        self.looping = True
+        self.color_index = 0
         self.is_playing = False
         self.is_recording = False
         self._notes: list[dict[str, object]] = []
         self._next_note_id = 1
+        self._automation_envelopes: dict[int, _AutomationEnvelope] = {}
 
         for note in notes or []:
             self._notes.append(dict(note))
@@ -102,6 +107,74 @@ class _Clip:
             note for note in self._notes if int(note["note_id"]) not in note_id_set
         ]
 
+    @property
+    def has_envelopes(self) -> bool:
+        return bool(self._automation_envelopes)
+
+    def automation_envelope(self, parameter) -> _AutomationEnvelope | None:
+        return self._automation_envelopes.get(id(parameter))
+
+    def create_automation_envelope(self, parameter) -> _AutomationEnvelope:
+        envelope = _AutomationEnvelope()
+        self._automation_envelopes[id(parameter)] = envelope
+        return envelope
+
+    def clear_envelope(self, parameter) -> None:
+        self._automation_envelopes.pop(id(parameter), None)
+
+
+class _AutomationEvent:
+    def __init__(
+        self,
+        time: float,
+        value: float | None,
+        step_length: float = 0.0,
+    ) -> None:
+        self.time = time
+        self.value = value
+        self.step_length = step_length
+
+
+class _AutomationEnvelope:
+    def __init__(self, events: list[_AutomationEvent] | None = None) -> None:
+        self.events = list(events or [])
+
+    def events_in_range(self, start: float, end: float):
+        stop = end if end >= start else start
+        return tuple(event for event in self.events if start <= event.time <= stop)
+
+    def insert_step(self, time: float, step_length: float, value: float) -> None:
+        self.events.append(_AutomationEvent(time, value, step_length))
+        self.events.sort(key=lambda event: event.time)
+
+
+class _UnreadableAutomationEnvelope:
+    def __init__(self, events: list[_AutomationEvent] | None = None) -> None:
+        self.events = list(events or [])
+
+    def insert_step(self, time: float, step_length: float, value: float) -> None:
+        self.events.append(_AutomationEvent(time, value, step_length))
+
+
+class _Parameter:
+    def __init__(
+        self,
+        name: str,
+        value: float,
+        minimum: float,
+        maximum: float,
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.min = minimum
+        self.max = maximum
+
+
+class _Device:
+    def __init__(self, name: str, parameters: list[_Parameter]) -> None:
+        self.name = name
+        self.parameters = parameters
+
 
 class _Slot:
     def __init__(self, clip: _Clip | None = None) -> None:
@@ -130,9 +203,16 @@ class _Slot:
         pass
 
 
-def _track_with_slots(*slots: _Slot, midi: bool = True, audio: bool = False) -> _Track:
+def _track_with_slots(
+    *slots: _Slot,
+    midi: bool = True,
+    audio: bool = False,
+    devices: list[_Device] | None = None,
+) -> _Track:
     track = _Track("Track", midi=midi, audio=audio)
     track.clip_slots = list(slots)
+    if devices is not None:
+        track.devices = devices
     return track
 
 
@@ -168,6 +248,22 @@ class _SongWithClipTracks(_FakeSong):
                     )
                 ),
                 _Slot(),
+                devices=[
+                    _Device(
+                        "Utility",
+                        [
+                            _Parameter("Gain", 0.0, -35.0, 35.0),
+                            _Parameter("Mute", 0.0, 0.0, 1.0),
+                        ],
+                    ),
+                    _Device(
+                        "Auto Filter",
+                        [
+                            _Parameter("Device On", 1.0, 0.0, 1.0),
+                            _Parameter("Frequency", 5000.0, 20.0, 20000.0),
+                        ],
+                    ),
+                ],
             ),
         ]
 
@@ -283,6 +379,79 @@ class TestSetNameFireStopGetInfo:
     def test_get_info_empty_raises(self, handler_clip: ClipHandler) -> None:
         with pytest.raises(NotFoundError, match="No clip"):
             handler_clip.handle_get_info({"track_index": 1, "clip_slot_index": 1})
+
+
+class TestLoopAndColor:
+    def test_set_loop_success(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        result = handler_clip.handle_set_loop(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "loop_start": 0.5,
+                "loop_end": 1.5,
+                "looping": True,
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "loop_start": 0.5,
+            "loop_end": 1.5,
+            "looping": True,
+        }
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        assert clip.loop_start == 0.5
+        assert clip.loop_end == 1.5
+        assert clip.looping is True
+
+    def test_set_loop_rejects_invalid_range(self, handler_clip: ClipHandler) -> None:
+        with pytest.raises(InvalidParamsError, match="loop_end"):
+            handler_clip.handle_set_loop(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 2,
+                    "loop_start": 2.0,
+                    "loop_end": 2.0,
+                }
+            )
+
+    def test_set_color_success(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        result = handler_clip.handle_set_color(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "color_index": 11,
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "color_index": 11,
+        }
+        assert song_clip.tracks[0].clip_slots[1].clip.color_index == 11
+
+    def test_set_color_missing_clip_raises_not_found(
+        self,
+        handler_clip: ClipHandler,
+    ) -> None:
+        with pytest.raises(NotFoundError, match="No clip"):
+            handler_clip.handle_set_color(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 1,
+                    "color_index": 3,
+                }
+            )
 
 
 class TestGetNotes:
@@ -488,5 +657,163 @@ class TestSetNotes:
                     "clip_slot_index": 2,
                     "from_pitch": 120,
                     "pitch_span": 16,
+                }
+            )
+
+
+class TestAutomation:
+    def test_get_automation_resolves_device_and_parameter(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        parameter = song_clip.tracks[0].devices[1].parameters[1]
+        clip._automation_envelopes[id(parameter)] = _AutomationEnvelope(
+            [
+                _AutomationEvent(0.0, 250.0),
+                _AutomationEvent(1.0, 5000.0, 0.5),
+            ]
+        )
+
+        result = handler_clip.handle_get_automation(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "device_index": 2,
+                "parameter_index": 2,
+            }
+        )
+
+        assert result["device_name"] == "Auto Filter"
+        assert result["parameter_name"] == "Frequency"
+        assert result["points"] == [
+            {"time": 0.0, "value": 250.0, "step_length": 0.0},
+            {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+        ]
+
+    def test_get_automation_skips_events_without_numeric_value(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        parameter = song_clip.tracks[0].devices[1].parameters[1]
+        clip._automation_envelopes[id(parameter)] = _AutomationEnvelope(
+            [
+                _AutomationEvent(0.0, 250.0),
+                _AutomationEvent(0.5, None),
+            ]
+        )
+
+        result = handler_clip.handle_get_automation(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "device_index": 2,
+                "parameter_index": 2,
+            }
+        )
+
+        assert result["points"] == [{"time": 0.0, "value": 250.0, "step_length": 0.0}]
+
+    def test_get_automation_skips_non_finite_values(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        parameter = song_clip.tracks[0].devices[1].parameters[1]
+        clip._automation_envelopes[id(parameter)] = _AutomationEnvelope(
+            [
+                _AutomationEvent(0.0, 250.0),
+                _AutomationEvent(0.5, float("nan")),
+            ]
+        )
+
+        result = handler_clip.handle_get_automation(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "device_index": 2,
+                "parameter_index": 2,
+            }
+        )
+
+        assert result["points"] == [{"time": 0.0, "value": 250.0, "step_length": 0.0}]
+
+    def test_set_automation_replaces_existing_envelope(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        parameter = song_clip.tracks[0].devices[1].parameters[1]
+        clip._automation_envelopes[id(parameter)] = _AutomationEnvelope(
+            [_AutomationEvent(0.0, 1000.0, 0.25)]
+        )
+
+        result = handler_clip.handle_set_automation(
+            {
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "device_index": 2,
+                "parameter_index": 2,
+                "points": [
+                    {"time": 0.0, "value": 250.0, "step_length": 0.25},
+                    {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+                ],
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "device_index": 2,
+            "parameter_index": 2,
+            "device_name": "Auto Filter",
+            "parameter_name": "Frequency",
+            "point_count": 2,
+        }
+        envelope = clip.automation_envelope(parameter)
+        assert envelope is not None
+        assert [(event.time, event.value) for event in envelope.events] == [
+            (0.0, 250.0),
+            (1.0, 5000.0),
+        ]
+
+    def test_set_automation_rejects_non_numeric_value(
+        self,
+        handler_clip: ClipHandler,
+    ) -> None:
+        with pytest.raises(InvalidParamsError, match="'points\\[1\\]'\\.value"):
+            handler_clip.handle_set_automation(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 2,
+                    "device_index": 2,
+                    "parameter_index": 2,
+                    "points": [{"time": 0.0, "value": "loud"}],
+                }
+            )
+
+    def test_get_automation_raises_when_events_are_unreadable(
+        self,
+        handler_clip: ClipHandler,
+        song_clip: _SongWithClipTracks,
+    ) -> None:
+        clip = song_clip.tracks[0].clip_slots[1].clip
+        parameter = song_clip.tracks[0].devices[1].parameters[1]
+        clip._automation_envelopes[id(parameter)] = _UnreadableAutomationEnvelope(
+            [_AutomationEvent(0.0, 250.0)]
+        )
+
+        with pytest.raises(RuntimeError, match="readable envelope events"):
+            handler_clip.handle_get_automation(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 2,
+                    "device_index": 2,
+                    "parameter_index": 2,
                 }
             )

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -169,6 +169,49 @@ class _SceneHandler:
         }
 
 
+class _ClipHandler:
+    def handle_set_loop(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_slot_index": params["clip_slot_index"],
+            "loop_start": params["loop_start"],
+            "loop_end": params["loop_end"],
+            "looping": params.get("looping", True),
+        }
+
+    def handle_set_color(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_slot_index": params["clip_slot_index"],
+            "color_index": params["color_index"],
+        }
+
+    def handle_get_automation(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_slot_index": params["clip_slot_index"],
+            "device_index": params["device_index"],
+            "parameter_index": params["parameter_index"],
+            "device_name": "Auto Filter",
+            "parameter_name": "Frequency",
+            "points": [
+                {"time": 0.0, "value": 250.0, "step_length": 0.0},
+                {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+            ],
+        }
+
+    def handle_set_automation(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_slot_index": params["clip_slot_index"],
+            "device_index": params["device_index"],
+            "parameter_index": params["parameter_index"],
+            "device_name": "Auto Filter",
+            "parameter_name": "Frequency",
+            "point_count": len(params["points"]),
+        }
+
+
 @pytest.fixture
 def tcp_server():
     """Start a real TcpServer in a background thread on an OS-assigned port."""
@@ -180,6 +223,7 @@ def tcp_server():
     dispatcher.register("mixer", _MixerHandler())
     dispatcher.register("arrangement", _ArrangementHandler())
     dispatcher.register("scene", _SceneHandler())
+    dispatcher.register("clip", _ClipHandler())
 
     logs: list[str] = []
     server = TcpServer(
@@ -398,5 +442,61 @@ class TestFullRoundTrip:
         assert resp.result["track_index"] is None
         assert resp.result["clips"][0]["name"] == "Verse"
         assert resp.result["clips"][0]["is_midi_clip"] is True
+
+        await conn.disconnect()
+
+    async def test_clip_loop_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(
+            command="clip.set_loop",
+            params={
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "loop_start": 0.0,
+                "loop_end": 4.0,
+                "looping": True,
+            },
+            id="clip-loop-1",
+        )
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "clip-loop-1"
+        assert resp.result == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "loop_start": 0.0,
+            "loop_end": 4.0,
+            "looping": True,
+        }
+
+        await conn.disconnect()
+
+    async def test_clip_automation_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(
+            command="clip.get_automation",
+            params={
+                "track_index": 1,
+                "clip_slot_index": 2,
+                "device_index": 1,
+                "parameter_index": 2,
+            },
+            id="clip-automation-1",
+        )
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "clip-automation-1"
+        assert resp.result is not None
+        assert resp.result["device_name"] == "Auto Filter"
+        assert resp.result["parameter_name"] == "Frequency"
+        assert resp.result["points"][1]["step_length"] == 0.5
 
         await conn.disconnect()

--- a/Tests/tools/test_clip.py
+++ b/Tests/tools/test_clip.py
@@ -13,9 +13,14 @@ if TYPE_CHECKING:
 from mcp_ableton._app import mcp
 from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
 from mcp_ableton.tools.clip import (
+    ClipAutomationPoint,
+    ClipAutomationResult,
+    ClipAutomationSetResult,
+    ClipColorResult,
     ClipCreatedResult,
     ClipDuplicatedResult,
     ClipInfo,
+    ClipLoopResult,
     ClipNote,
     ClipNotesResult,
     ClipRenamedResult,
@@ -28,9 +33,13 @@ from mcp_ableton.tools.clip import (
     delete_clip,
     duplicate_clip,
     fire_clip,
+    get_clip_automation,
     get_clip_info,
     get_clip_notes,
     remove_notes,
+    set_clip_automation,
+    set_clip_color,
+    set_clip_loop,
     set_clip_name,
     set_clip_notes,
     stop_clip,
@@ -44,8 +53,12 @@ TOOL_NAMES = [
     "fire_clip",
     "stop_clip",
     "get_clip_info",
+    "set_clip_loop",
+    "set_clip_color",
     "get_clip_notes",
+    "get_clip_automation",
     "add_notes_to_clip",
+    "set_clip_automation",
     "remove_notes",
     "set_clip_notes",
 ]
@@ -103,6 +116,43 @@ CLIP_NOTES_RESULT = {
     ],
 }
 
+CLIP_LOOP_RESULT = {
+    "track_index": 1,
+    "clip_slot_index": 2,
+    "loop_start": 0.0,
+    "loop_end": 4.0,
+    "looping": True,
+}
+
+CLIP_COLOR_RESULT = {
+    "track_index": 1,
+    "clip_slot_index": 2,
+    "color_index": 17,
+}
+
+CLIP_AUTOMATION_RESULT = {
+    "track_index": 1,
+    "clip_slot_index": 2,
+    "device_index": 1,
+    "parameter_index": 2,
+    "device_name": "Auto Filter",
+    "parameter_name": "Frequency",
+    "points": [
+        {"time": 0.0, "value": 250.0},
+        {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+    ],
+}
+
+CLIP_AUTOMATION_SET_RESULT = {
+    "track_index": 1,
+    "clip_slot_index": 2,
+    "device_index": 1,
+    "parameter_index": 2,
+    "device_name": "Auto Filter",
+    "parameter_name": "Frequency",
+    "point_count": 2,
+}
+
 
 class TestToolContracts:
     def _get_tool(self, name: str):
@@ -130,6 +180,22 @@ class TestToolContracts:
         props = tool.parameters["properties"]
         assert props["notes"]["minItems"] == 1
 
+    def test_set_clip_loop_schema(self) -> None:
+        tool = self._get_tool("set_clip_loop")
+        props = tool.parameters["properties"]
+        assert props["loop_start"]["minimum"] == 0.0
+        assert props["looping"]["default"] is True
+
+    def test_set_clip_color_schema(self) -> None:
+        tool = self._get_tool("set_clip_color")
+        props = tool.parameters["properties"]
+        assert props["color_index"]["minimum"] == 0
+
+    def test_set_clip_automation_schema(self) -> None:
+        tool = self._get_tool("set_clip_automation")
+        props = tool.parameters["properties"]
+        assert props["points"]["minItems"] == 1
+
     def test_remove_notes_schema(self) -> None:
         tool = self._get_tool("remove_notes")
         props = tool.parameters["properties"]
@@ -156,6 +222,43 @@ class TestInputValidation:
         model = self._arg_model("create_clip")
         with pytest.raises(ValidationError):
             model(track_index=1, clip_slot_index=1, length=0.0)
+
+    def test_set_clip_loop_rejects_negative_start(self) -> None:
+        model = self._arg_model("set_clip_loop")
+        with pytest.raises(ValidationError):
+            model(
+                track_index=1,
+                clip_slot_index=1,
+                loop_start=-0.1,
+                loop_end=4.0,
+            )
+
+    def test_set_clip_color_rejects_negative_index(self) -> None:
+        model = self._arg_model("set_clip_color")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_slot_index=1, color_index=-1)
+
+    def test_set_clip_automation_rejects_empty_point_list(self) -> None:
+        model = self._arg_model("set_clip_automation")
+        with pytest.raises(ValidationError):
+            model(
+                track_index=1,
+                clip_slot_index=1,
+                device_index=1,
+                parameter_index=1,
+                points=[],
+            )
+
+    def test_set_clip_automation_rejects_negative_point_time(self) -> None:
+        model = self._arg_model("set_clip_automation")
+        with pytest.raises(ValidationError):
+            model(
+                track_index=1,
+                clip_slot_index=1,
+                device_index=1,
+                parameter_index=1,
+                points=[{"time": -0.1, "value": 0.5}],
+            )
 
     def test_add_notes_accepts_lean_note_arrays(self) -> None:
         model = self._arg_model("add_notes_to_clip")
@@ -302,6 +405,158 @@ class TestGetClipNotes:
         req = mock_connection.send_command.call_args[0][0]
         assert req.command == "clip.get_notes"
         assert req.params == {"track_index": 1, "clip_slot_index": 2}
+
+
+class TestSetClipLoop:
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(CLIP_LOOP_RESULT)
+
+        result = await set_clip_loop(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            loop_start=0.0,
+            loop_end=4.0,
+        )
+
+        assert isinstance(result, ClipLoopResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.set_loop"
+        assert req.params == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "loop_start": 0.0,
+            "loop_end": 4.0,
+            "looping": True,
+        }
+
+    async def test_rejects_invalid_range_before_send(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        with pytest.raises(ValueError, match="loop_end"):
+            await set_clip_loop(
+                ctx=mock_context,
+                track_index=1,
+                clip_slot_index=2,
+                loop_start=4.0,
+                loop_end=4.0,
+            )
+
+        mock_connection.send_command.assert_not_called()
+
+
+class TestSetClipColor:
+    async def test_returns_color_result(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(CLIP_COLOR_RESULT)
+
+        result = await set_clip_color(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            color_index=17,
+        )
+
+        assert isinstance(result, ClipColorResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.set_color"
+        assert req.params == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "color_index": 17,
+        }
+
+
+class TestClipAutomation:
+    async def test_get_clip_automation_returns_points(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(CLIP_AUTOMATION_RESULT)
+
+        result = await get_clip_automation(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            device_index=1,
+            parameter_index=2,
+        )
+
+        assert isinstance(result, ClipAutomationResult)
+        assert isinstance(result.points[0], ClipAutomationPoint)
+        assert result.points[0].step_length == 0.0
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.get_automation"
+        assert req.params == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "device_index": 1,
+            "parameter_index": 2,
+        }
+
+    async def test_set_clip_automation_sends_points(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _ok_response(
+            CLIP_AUTOMATION_SET_RESULT
+        )
+
+        result = await set_clip_automation(
+            ctx=mock_context,
+            track_index=1,
+            clip_slot_index=2,
+            device_index=1,
+            parameter_index=2,
+            points=[
+                {"time": 0.0, "value": 250.0},
+                {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+            ],
+        )
+
+        assert isinstance(result, ClipAutomationSetResult)
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.set_automation"
+        assert req.params == {
+            "track_index": 1,
+            "clip_slot_index": 2,
+            "device_index": 1,
+            "parameter_index": 2,
+            "points": [
+                {"time": 0.0, "value": 250.0, "step_length": 0.0},
+                {"time": 1.0, "value": 5000.0, "step_length": 0.5},
+            ],
+        }
+
+    async def test_get_clip_automation_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+    ) -> None:
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message="Parameter 2 does not exist",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await get_clip_automation(
+                ctx=mock_context,
+                track_index=1,
+                clip_slot_index=2,
+                device_index=1,
+                parameter_index=2,
+            )
 
 
 class TestAddNotesToClip:
@@ -595,6 +850,11 @@ class TestDeleteDuplicateFireStop:
 
 
 class TestResponseModels:
+    def test_clip_automation_accepts_valid(self) -> None:
+        automation = ClipAutomationResult.model_validate(CLIP_AUTOMATION_RESULT)
+        assert automation.parameter_name == "Frequency"
+        assert automation.points[1].step_length == 0.5
+
     def test_clip_info_rejects_missing_fields(self) -> None:
         with pytest.raises(ValidationError):
             ClipInfo.model_validate({"track_index": 1})

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -332,6 +332,15 @@ These tools match or exceed the original ahujasid feature set, add arrangement v
 
 `NoteInput` accepts both lean format `[pitch, start_time, duration, velocity]` and object format `{pitch, start_time, duration, velocity, mute?, velocity_deviation?, probability?}`.
 
+#### Clip Properties (4 tools)
+
+| Tool | Parameters | Returns | LOM Calls |
+|------|-----------|---------|-----------|
+| `set_clip_loop` | `track_index, clip_index, loop_start: float, loop_end: float, looping: bool = True` | `ClipLoopResult` | `clip.loop_start = ...`, `clip.loop_end = ...`, `clip.looping = ...` |
+| `set_clip_color` | `track_index, clip_index, color_index: int` | `ClipColorResult` | `clip.color_index = color_index` |
+| `get_clip_automation` | `track_index, clip_index, device_index, parameter_index` | `ClipAutomationResult` | `clip.automation_envelope(parameter)`, `envelope.events_in_range(...)` |
+| `set_clip_automation` | `track_index, clip_index, device_index, parameter_index, points: list[ClipAutomationPoint]` | `ClipAutomationSetResult` | `clip.clear_envelope(parameter)`, `clip.create_automation_envelope(parameter)`, `envelope.insert_step(...)` |
+
 #### Device Management (4 tools)
 
 | Tool | Parameters | Returns | LOM Calls |
@@ -508,8 +517,20 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `stop_scene` | `scene.stop` |
 | `set_scene_name` | `scene.set_name` |
 | `create_clip` | `clip.create` |
+| `delete_clip` | `clip.delete` |
+| `duplicate_clip` | `clip.duplicate` |
+| `set_clip_name` | `clip.set_name` |
+| `fire_clip` | `clip.fire` |
+| `stop_clip` | `clip.stop` |
+| `get_clip_info` | `clip.get_info` |
+| `set_clip_loop` | `clip.set_loop` |
+| `set_clip_color` | `clip.set_color` |
 | `add_notes_to_clip` | `clip.add_notes` |
 | `get_clip_notes` | `clip.get_notes` |
+| `remove_notes` | `clip.remove_notes` |
+| `set_clip_notes` | `clip.set_notes` |
+| `get_clip_automation` | `clip.get_automation` |
+| `set_clip_automation` | `clip.set_automation` |
 | `get_arrangement_clips` | `arrangement.get_clips` |
 | `create_arrangement_clip` | `arrangement.create_clip` |
 | `move_arrangement_clip` | `arrangement.move_clip` |

--- a/remote_script/AbletonLiveMCP/handlers/clip.py
+++ b/remote_script/AbletonLiveMCP/handlers/clip.py
@@ -6,6 +6,7 @@ LOM uses 0-based indices on ``song.tracks`` and ``track.clip_slots``.
 
 from __future__ import annotations
 
+import math
 from collections import Counter
 from typing import Any
 
@@ -24,19 +25,26 @@ NOTE_INPUT_KEYS = frozenset(
     }
 )
 
+AUTOMATION_POINT_KEYS = frozenset({"time", "value", "step_length"})
+
 
 class ClipHandler(BaseHandler):
     """Handle session clip slot commands."""
 
+    def _require_index(self, params: dict[str, Any], name: str) -> int:
+        """Return a validated 1-based index parameter."""
+        raw_value = params.get(name)
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            raise InvalidParamsError(f"'{name}' must be an integer")
+        if raw_value < 1:
+            raise InvalidParamsError(f"'{name}' must be at least 1")
+        return raw_value
+
     def _resolve_track(self, params: dict[str, Any]) -> tuple[Any, int, int]:
         """Return ``(track, track_index_1based, lo_track)`` or raise."""
-        raw = params.get("track_index")
-        if raw is None:
-            raise InvalidParamsError("'track_index' parameter is required")
-        if not isinstance(raw, int):
-            raise InvalidParamsError("'track_index' must be an integer")
-        if raw < 1:
-            raise InvalidParamsError("'track_index' must be at least 1")
+        raw = self._require_index(params, "track_index")
 
         song = self._song
         tracks = song.tracks
@@ -52,13 +60,7 @@ class ClipHandler(BaseHandler):
     ) -> tuple[Any, Any, int, int, int]:
         """Return ``(track, clip_slot, track_index_1, clip_slot_index_1, lo_slot)``."""
         track, track_index, _lo_track = self._resolve_track(params)
-        raw_slot = params.get("clip_slot_index")
-        if raw_slot is None:
-            raise InvalidParamsError("'clip_slot_index' parameter is required")
-        if not isinstance(raw_slot, int):
-            raise InvalidParamsError("'clip_slot_index' must be an integer")
-        if raw_slot < 1:
-            raise InvalidParamsError("'clip_slot_index' must be at least 1")
+        raw_slot = self._require_index(params, "clip_slot_index")
 
         slots = track.clip_slots
         ns = len(slots)
@@ -70,19 +72,83 @@ class ClipHandler(BaseHandler):
         lo = raw_slot - 1
         return track, slots[lo], track_index, raw_slot, lo
 
-    def _resolve_midi_clip(self, params: dict[str, Any]) -> tuple[Any, int, int]:
-        """Return ``(clip, track_index_1based, clip_slot_index_1based)`` or raise."""
-        _track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(params)
+    def _resolve_existing_clip(
+        self,
+        params: dict[str, Any],
+    ) -> tuple[Any, Any, int, int]:
+        """Return ``(track, clip, track_index_1based, clip_slot_index_1based)``."""
+        track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(params)
         if not slot.has_clip:
             raise NotFoundError(f"No clip in slot {slot_index} on track {track_index}")
+        return track, slot.clip, track_index, slot_index
 
-        clip = slot.clip
+    def _resolve_midi_clip(self, params: dict[str, Any]) -> tuple[Any, int, int]:
+        """Return ``(clip, track_index_1based, clip_slot_index_1based)`` or raise."""
+        _track, clip, track_index, slot_index = self._resolve_existing_clip(params)
         if not bool(clip.is_midi_clip):
             raise InvalidParamsError(
                 f"Clip slot {slot_index} on track {track_index} is not a MIDI clip"
             )
 
         return clip, track_index, slot_index
+
+    def _resolve_device(
+        self,
+        track: Any,
+        track_index: int,
+        device_index: int,
+    ) -> Any:
+        """Resolve a 1-based device index on a track."""
+        devices = list(track.devices)
+        device_count = len(devices)
+        if device_index > device_count:
+            raise NotFoundError(
+                f"Device {device_index} does not exist on track {track_index} "
+                f"(track has {device_count} device(s))"
+            )
+        return devices[device_index - 1]
+
+    def _resolve_parameter(
+        self,
+        device: Any,
+        track_index: int,
+        device_index: int,
+        parameter_index: int,
+    ) -> Any:
+        """Resolve a 1-based parameter index on a device."""
+        parameters = list(device.parameters)
+        parameter_count = len(parameters)
+        if parameter_index > parameter_count:
+            raise NotFoundError(
+                f"Parameter {parameter_index} does not exist on device {device_index} "
+                f"of track {track_index} (device has {parameter_count} parameter(s))"
+            )
+        return parameters[parameter_index - 1]
+
+    def _resolve_clip_automation_target(
+        self,
+        params: dict[str, Any],
+    ) -> tuple[Any, Any, Any, int, int, int, int]:
+        """Resolve clip, device, and parameter for clip automation commands."""
+        track, clip, track_index, slot_index = self._resolve_existing_clip(params)
+        device_index = self._require_index(params, "device_index")
+        parameter_index = self._require_index(params, "parameter_index")
+        device = self._resolve_device(track, track_index, device_index)
+        parameter = self._resolve_parameter(
+            device,
+            track_index,
+            device_index,
+            parameter_index,
+        )
+        return (
+            clip,
+            device,
+            parameter,
+            track_index,
+            slot_index,
+            device_index,
+            parameter_index,
+        )
 
     def _get_clip_notes(self, clip: Any) -> list[dict[str, Any]]:
         """Read notes from Ableton and normalize the response container shape."""
@@ -237,6 +303,63 @@ class ClipHandler(BaseHandler):
                 )
 
             normalized.append(normalized_note)
+
+        return normalized
+
+    def _normalize_automation_points(
+        self,
+        params: dict[str, Any],
+        *,
+        minimum_value: float | None = None,
+        maximum_value: float | None = None,
+    ) -> list[dict[str, float]]:
+        """Validate clip automation points received over TCP."""
+        raw_points = params.get("points")
+        if raw_points is None:
+            raise InvalidParamsError("'points' parameter is required")
+        if not isinstance(raw_points, list):
+            raise InvalidParamsError("'points' must be a list")
+        if not raw_points:
+            raise InvalidParamsError("'points' must contain at least one point")
+
+        normalized: list[dict[str, float]] = []
+        for index, point in enumerate(raw_points, start=1):
+            label = f"'points[{index}]'"
+            if not isinstance(point, dict):
+                raise InvalidParamsError(f"{label} must be an object")
+
+            unknown_keys = set(point) - AUTOMATION_POINT_KEYS
+            if unknown_keys:
+                keys = ", ".join(sorted(unknown_keys))
+                raise InvalidParamsError(f"{label} has unexpected keys: {keys}")
+
+            time = self._require_number(
+                point,
+                "time",
+                label=label,
+                minimum=0.0,
+            )
+            value = self._require_number(
+                point,
+                "value",
+                label=label,
+                minimum=minimum_value,
+                maximum=maximum_value,
+            )
+            step_length = self._require_optional_number(
+                point.get("step_length", 0.0),
+                name="step_length",
+                label=label,
+                minimum=0.0,
+            )
+
+            normalized.append(
+                {
+                    "time": time,
+                    "value": value,
+                    "step_length": step_length,
+                }
+            )
 
         return normalized
 
@@ -434,6 +557,103 @@ class ClipHandler(BaseHandler):
                 continue
             added_note_ids.append(int(note["note_id"]))
         return added_note_ids
+
+    def _clip_automation_envelope(self, clip: Any, parameter: Any) -> Any | None:
+        """Return the envelope for a clip/parameter pair if the runtime exposes it."""
+        get_envelope = getattr(clip, "automation_envelope", None)
+        if callable(get_envelope):
+            envelope = get_envelope(parameter)
+            if envelope is not None:
+                return envelope
+        return None
+
+    def _create_clip_automation_envelope(self, clip: Any, parameter: Any) -> Any | None:
+        """Create and return the envelope for a clip/parameter pair."""
+        envelope = self._clip_automation_envelope(clip, parameter)
+        if envelope is not None:
+            return envelope
+
+        create_envelope = getattr(clip, "create_automation_envelope", None)
+        if not callable(create_envelope):
+            raise RuntimeError(
+                "This Ableton Live runtime does not expose clip automation envelopes"
+            )
+
+        created = create_envelope(parameter)
+        if created is not None:
+            return created
+
+        return self._clip_automation_envelope(clip, parameter)
+
+    def _serialize_automation_point(self, point: Any) -> dict[str, float] | None:
+        """Return the canonical outbound automation point representation."""
+        if isinstance(point, dict):
+            raw_value = point.get("value")
+            if raw_value is None:
+                return None
+            time = float(point["time"])
+            value = float(raw_value)
+            step_length = float(point.get("step_length", 0.0))
+        else:
+            raw_value = getattr(point, "value", None)
+            if raw_value is None:
+                return None
+            time = float(point.time)
+            value = float(raw_value)
+            step_length = float(getattr(point, "step_length", 0.0))
+        components = (time, value, step_length)
+        if not all(math.isfinite(component) for component in components):
+            return None
+
+        return {
+            "time": time,
+            "value": value,
+            "step_length": step_length,
+        }
+
+    def _get_clip_automation_points(
+        self,
+        clip: Any,
+        parameter: Any,
+    ) -> list[dict[str, float]]:
+        """Read automation events for one clip envelope using the runtime API."""
+        envelope = self._clip_automation_envelope(clip, parameter)
+        if envelope is None:
+            return []
+
+        events_in_range = getattr(envelope, "events_in_range", None)
+        if not callable(events_in_range):
+            raise RuntimeError(
+                "Clip automation envelopes exist, but this Ableton Live runtime "
+                "does not expose readable envelope events"
+            )
+
+        loop_start = float(getattr(clip, "loop_start", 0.0))
+        loop_end = float(getattr(clip, "loop_end", getattr(clip, "length", 0.0)))
+        clip_length = float(getattr(clip, "length", 0.0))
+        ranges = [
+            (loop_start, loop_end),
+            (loop_start, max(0.0, loop_end - loop_start)),
+            (0.0, clip_length),
+        ]
+
+        errors: list[str] = []
+        for start, second_arg in ranges:
+            try:
+                raw_events = events_in_range(start, second_arg)
+                points: list[dict[str, float]] = []
+                for event in list(raw_events):
+                    serialized = self._serialize_automation_point(event)
+                    if serialized is not None:
+                        points.append(serialized)
+                return points
+            except Exception as exc:
+                errors.append(f"events_in_range({start}, {second_arg}) failed: {exc}")
+
+        raise RuntimeError(
+            "Clip automation envelopes are present, but envelope events could not "
+            f"be read on this runtime ({'; '.join(errors)})"
+        )
 
     def _write_notes(
         self,
@@ -662,6 +882,148 @@ class ClipHandler(BaseHandler):
                 "track_index": track_index,
                 "clip_slot_index": slot_index,
                 "notes": notes,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_set_loop(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set loop start/end and looping state for an existing session clip."""
+        loop_start = self._require_optional_number(
+            params.get("loop_start"),
+            name="loop_start",
+            label="params",
+            minimum=0.0,
+        )
+        loop_end = self._require_optional_number(
+            params.get("loop_end"),
+            name="loop_end",
+            label="params",
+            minimum=0.0,
+        )
+        if loop_end <= loop_start:
+            raise InvalidParamsError("'loop_end' must be greater than 'loop_start'")
+
+        looping = params.get("looping", True)
+        if not isinstance(looping, bool):
+            raise InvalidParamsError("'looping' must be a boolean")
+
+        def _do() -> dict[str, Any]:
+            _track, clip, track_index, slot_index = self._resolve_existing_clip(params)
+            try:
+                clip.loop_start = loop_start
+                clip.loop_end = loop_end
+                clip.looping = looping
+            except Exception as exc:
+                raise InvalidParamsError(
+                    f"Failed to set clip loop settings: {exc}"
+                ) from exc
+
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "loop_start": float(clip.loop_start),
+                "loop_end": float(clip.loop_end),
+                "looping": bool(clip.looping),
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_set_color(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set the color index for an existing session clip."""
+        color_index = params.get("color_index")
+        if color_index is None:
+            raise InvalidParamsError("'color_index' parameter is required")
+        if isinstance(color_index, bool) or not isinstance(color_index, int):
+            raise InvalidParamsError("'color_index' must be an integer")
+        if color_index < 0:
+            raise InvalidParamsError("'color_index' must be at least 0")
+
+        def _do() -> dict[str, Any]:
+            _track, clip, track_index, slot_index = self._resolve_existing_clip(params)
+            clip.color_index = color_index
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "color_index": int(clip.color_index),
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_get_automation(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Return automation points for a clip envelope on one device parameter."""
+
+        def _do() -> dict[str, Any]:
+            (
+                clip,
+                device,
+                parameter,
+                track_index,
+                slot_index,
+                device_index,
+                parameter_index,
+            ) = self._resolve_clip_automation_target(params)
+            points = self._get_clip_automation_points(clip, parameter)
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "device_index": device_index,
+                "parameter_index": parameter_index,
+                "device_name": str(getattr(device, "name", "")),
+                "parameter_name": str(getattr(parameter, "name", "")),
+                "points": points,
+            }
+
+        return self._run_on_main_thread(_do)
+
+    def handle_set_automation(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Replace one clip envelope with the supplied automation points."""
+
+        def _do() -> dict[str, Any]:
+            (
+                clip,
+                device,
+                parameter,
+                track_index,
+                slot_index,
+                device_index,
+                parameter_index,
+            ) = self._resolve_clip_automation_target(params)
+            points = self._normalize_automation_points(params)
+
+            clear_envelope = getattr(clip, "clear_envelope", None)
+            if not callable(clear_envelope):
+                raise RuntimeError(
+                    "This Ableton Live runtime does not expose clip.clear_envelope"
+                )
+
+            try:
+                clear_envelope(parameter)
+                envelope = self._create_clip_automation_envelope(clip, parameter)
+                if envelope is None:
+                    raise RuntimeError(
+                        "Ableton Live did not return a clip automation envelope"
+                    )
+                for point in points:
+                    envelope.insert_step(
+                        point["time"],
+                        point["step_length"],
+                        point["value"],
+                    )
+            except InvalidParamsError:
+                raise
+            except Exception as exc:
+                raise InvalidParamsError(
+                    f"Failed to set clip automation: {exc}"
+                ) from exc
+
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "device_index": device_index,
+                "parameter_index": parameter_index,
+                "device_name": str(getattr(device, "name", "")),
+                "parameter_name": str(getattr(parameter, "name", "")),
+                "point_count": len(points),
             }
 
         return self._run_on_main_thread(_do)

--- a/src/mcp_ableton/tools/clip.py
+++ b/src/mcp_ableton/tools/clip.py
@@ -68,6 +68,24 @@ class ClipInfo(BaseModel):
     is_recording: bool
 
 
+class ClipLoopResult(BaseModel):
+    """Result of ``set_clip_loop``."""
+
+    track_index: int
+    clip_slot_index: int
+    loop_start: float
+    loop_end: float
+    looping: bool
+
+
+class ClipColorResult(BaseModel):
+    """Result of ``set_clip_color``."""
+
+    track_index: int
+    clip_slot_index: int
+    color_index: int
+
+
 class NoteObjectInput(BaseModel):
     """Structured note input accepted by note-editing tools."""
 
@@ -97,6 +115,40 @@ class ClipNote(BaseModel):
     mute: bool
     probability: float | None = None
     velocity_deviation: float | None = None
+
+
+class ClipAutomationPoint(BaseModel):
+    """A single clip automation point or step."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    time: float = Field(ge=0.0)
+    value: float
+    step_length: float = Field(default=0.0, ge=0.0)
+
+
+class ClipAutomationResult(BaseModel):
+    """Clip automation points for a specific device parameter."""
+
+    track_index: int
+    clip_slot_index: int
+    device_index: int
+    parameter_index: int
+    device_name: str
+    parameter_name: str
+    points: list[ClipAutomationPoint]
+
+
+class ClipAutomationSetResult(BaseModel):
+    """Result of ``set_clip_automation``."""
+
+    track_index: int
+    clip_slot_index: int
+    device_index: int
+    parameter_index: int
+    device_name: str
+    parameter_name: str
+    point_count: int
 
 
 class ClipNotesResult(BaseModel):
@@ -343,6 +395,77 @@ async def get_clip_info(
 
 
 @mcp.tool()
+async def set_clip_loop(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    loop_start: Annotated[
+        float,
+        Field(
+            description="Loop start in clip beat time (must be >= 0).",
+            ge=0.0,
+        ),
+    ],
+    loop_end: Annotated[
+        float,
+        Field(
+            description="Loop end in clip beat time (must be > loop_start).",
+            gt=0.0,
+        ),
+    ],
+    looping: Annotated[
+        bool,
+        Field(description="Whether clip looping should be enabled."),
+    ] = True,
+) -> ClipLoopResult:
+    """Set loop start/end and loop enabled state for a session clip."""
+    if loop_end <= loop_start:
+        raise ValueError("'loop_end' must be greater than 'loop_start'")
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.set_loop",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "loop_start": loop_start,
+            "loop_end": loop_end,
+            "looping": looping,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipLoopResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_clip_color(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    color_index: Annotated[
+        int,
+        Field(
+            description="Clip color index (must be >= 0).",
+            ge=0,
+        ),
+    ],
+) -> ClipColorResult:
+    """Set the color index for a session clip."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.set_color",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "color_index": color_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipColorResult.model_validate(response.result)
+
+
+@mcp.tool()
 async def get_clip_notes(
     ctx: Context,
     track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
@@ -360,6 +483,36 @@ async def get_clip_notes(
     response = await connection.send_command(request)
     response.raise_on_error()
     return ClipNotesResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def get_clip_automation(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    device_index: Annotated[
+        int,
+        Field(description="1-based device index on the track.", ge=1),
+    ],
+    parameter_index: Annotated[
+        int,
+        Field(description="1-based parameter index on the device.", ge=1),
+    ],
+) -> ClipAutomationResult:
+    """Get clip automation points for a device parameter on the host track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.get_automation",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "device_index": device_index,
+            "parameter_index": parameter_index,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipAutomationResult.model_validate(response.result)
 
 
 @mcp.tool()
@@ -393,6 +546,50 @@ async def add_notes_to_clip(
     response = await connection.send_command(request)
     response.raise_on_error()
     return NotesAddedResult.model_validate(response.result)
+
+
+@mcp.tool()
+async def set_clip_automation(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    device_index: Annotated[
+        int,
+        Field(description="1-based device index on the track.", ge=1),
+    ],
+    parameter_index: Annotated[
+        int,
+        Field(description="1-based parameter index on the device.", ge=1),
+    ],
+    points: Annotated[
+        list[ClipAutomationPoint],
+        Field(
+            description=(
+                "Replacement automation points. Each point includes time, value, "
+                "and optional step_length."
+            ),
+            min_length=1,
+        ),
+    ],
+) -> ClipAutomationSetResult:
+    """Replace clip automation for a device parameter with the supplied points."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.set_automation",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "device_index": device_index,
+            "parameter_index": parameter_index,
+            "points": [
+                ClipAutomationPoint.model_validate(point).model_dump(mode="python")
+                for point in points
+            ],
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ClipAutomationSetResult.model_validate(response.result)
 
 
 @mcp.tool()
@@ -483,10 +680,15 @@ async def set_clip_notes(
 
 
 __all__ = [
+    "ClipAutomationPoint",
+    "ClipAutomationResult",
+    "ClipAutomationSetResult",
+    "ClipColorResult",
     "ClipNote",
     "ClipCreatedResult",
     "ClipDuplicatedResult",
     "ClipInfo",
+    "ClipLoopResult",
     "ClipNotesResult",
     "ClipRenamedResult",
     "ClipSlotResult",
@@ -501,9 +703,13 @@ __all__ = [
     "delete_clip",
     "duplicate_clip",
     "fire_clip",
+    "get_clip_automation",
     "get_clip_info",
     "get_clip_notes",
     "remove_notes",
+    "set_clip_automation",
+    "set_clip_color",
+    "set_clip_loop",
     "set_clip_notes",
     "set_clip_name",
     "stop_clip",


### PR DESCRIPTION
## Summary
- add clip loop, color, and automation MCP tools to the existing clip tool surface
- extend the Remote Script clip handler with session-clip loop/color writes and clip envelope read/write support
- cover the new tool and handler paths with unit and integration tests

## MCP tools
- `set_clip_loop(track_index, clip_slot_index, loop_start, loop_end, looping=True)`
- `set_clip_color(track_index, clip_slot_index, color_index)`
- `get_clip_automation(track_index, clip_slot_index, device_index, parameter_index)`
- `set_clip_automation(track_index, clip_slot_index, device_index, parameter_index, points)`

## Remote Script
- register `clip.set_loop`, `clip.set_color`, `clip.get_automation`, and `clip.set_automation` in the existing clip handler path
- resolve session clips, devices, and parameters using the existing 1-based conventions
- run clip reads and writes on Live's main thread
- implement clip envelope access on Live 12.2.5 via `automation_envelope`, `create_automation_envelope`, `clear_envelope`, `insert_step`, and `events_in_range`

## Tests
- extend `Tests/tools/test_clip.py` for registration, schema/defaults, validation, command construction, and response handling
- extend `Tests/test_clip_handler.py` for loop/color success and error paths plus automation success/error coverage
- extend `Tests/test_integration.py` for end-to-end TCP payload coverage
- validation run:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification
- verified `get_session_info` still works through the stdio MCP server path
- created a disposable MIDI track and session clip in Live 12.2.5
- verified `set_clip_loop` updated the clip loop in Live
- verified `set_clip_color` updated the clip color index in Live
- loaded `Auto Filter` on the host track and verified `set_clip_automation` and `get_clip_automation` end-to-end against a real clip envelope
- checked Ableton `Log.txt` after the smoke run and saw no traceback or handler error for these commands

## Docs
- update the roadmap/command mapping in `docs/decisions/002-competitor-analysis-and-tool-roadmap.md`
- refresh the README shipped-status summary to include clip properties and clip automation

## Runtime notes
- on Live 12.2.5, clip automation is exposed through clip envelope APIs rather than through the generic device parameter setters
- envelope point values do not reliably round-trip against `DeviceParameter.min`/`max`; Live may return transformed/native values for the same target parameter
- some envelope reads can yield null-like or non-finite events, so the MCP response filters those entries instead of returning invalid structured data

Closes #17