### PR TITLE
Add audio file import MCP tools and handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/malmazuke/Ableton-Live-MCP/actions/workflows/ci.yml)
 
-> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **clip properties and clip automation**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **mixer tools including sends/returns and return-track control** are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
+> **🚧 Work in Progress** — Ableton Live MCP is usable today for the current shipped tool surface: **session/transport/recording**, **track management**, **scene management**, **session clip**, **session and arrangement audio import**, **clip properties and clip automation**, **MIDI note**, **arrangement clip**, **browser**, **device/parameter**, and **mixer tools including sends/returns and return-track control** are implemented. More domains are still in flight. Follow along on the [project board](https://github.com/users/malmazuke/projects/1) to see what's being built.
 
 Control Ableton Live with AI. Ask your AI assistant to create tracks, add clips, tweak devices, mix — anything you'd normally do by hand in Ableton.
 
@@ -170,7 +170,7 @@ troubleshooting guide.
 
 ## Current status
 
-The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, clip loop/color editing, clip automation read/write, MIDI notes, arrangement clips, browser navigation, device parameters, and mixer control for track volume/pan, sends, return tracks, and master volume. Remaining work focuses on the rest of the roadmap such as broader return/master addressing and undo/redo.
+The communication layer between the MCP server and Ableton's Remote Script is built and tested. The current implementation now includes transport/session/recording, track management, scene management, session clips, audio file import to session and arrangement, clip loop/color editing, clip automation read/write, MIDI notes, arrangement clips, browser navigation, device parameters, and mixer control for track volume/pan, sends, return tracks, and master volume. Remaining work focuses on the rest of the roadmap such as broader return/master addressing and undo/redo.
 
 See the [project board](https://github.com/users/malmazuke/projects/1) for detailed progress and planned work.
 
@@ -187,8 +187,8 @@ See the [project board](https://github.com/users/malmazuke/projects/1) for detai
 |------|----------|
 | Transport & session | Play, stop, record, set tempo, time signature, loop |
 | Tracks | Create MIDI/audio tracks, rename, delete, configure routing |
-| Arrangement clips | Create, move, and edit clips in arrangement view |
-| Session clips | Fire, stop, and manage clips in session view |
+| Arrangement clips | Create, move, import, and edit clips in arrangement view |
+| Session clips | Fire, stop, import, and manage clips in session view |
 | Devices & parameters | Load instruments/effects, read and tweak parameters |
 | Scenes | Create, fire, and manage scenes |
 | Mixing | Volume, pan, sends, solo, mute, arm |

--- a/Tests/test_arrangement_handler.py
+++ b/Tests/test_arrangement_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -103,6 +104,14 @@ class _ArrangementTrack(_Track):
             raise RuntimeError("track does not accept MIDI clips")
         self.arrangement_clips.append(
             _ArrangementClip("New MIDI Clip", start_time, length, audio=False)
+        )
+        self._sort_arrangement_clips()
+
+    def create_audio_clip(self, file_path: str, start_time: float) -> None:
+        if not self.has_audio_input:
+            raise RuntimeError("track does not accept audio clips")
+        self.arrangement_clips.append(
+            _ArrangementClip(Path(file_path).stem, start_time, 9.25, audio=True)
         )
         self._sort_arrangement_clips()
 
@@ -253,6 +262,85 @@ class TestCreateArrangementClip:
         with pytest.raises(InvalidParamsError, match="does not accept MIDI clips"):
             arrangement_handler.handle_create_clip(
                 {"track_index": 2, "start_time": 8.0, "length": 4.0}
+            )
+
+
+class TestImportAudioToArrangement:
+    def test_success_on_audio_track(
+        self,
+        arrangement_handler: ArrangementHandler,
+        arrangement_song: _ArrangementSong,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "vocal.wav"
+        file_path.write_bytes(b"RIFF")
+
+        result = arrangement_handler.handle_import_audio(
+            {
+                "track_index": 2,
+                "file_path": str(file_path),
+                "start_time": 12.0,
+            }
+        )
+
+        assert result == {
+            "track_index": 2,
+            "clip_index": 2,
+            "name": "vocal",
+            "file_path": str(file_path),
+            "start_time": 12.0,
+            "length": 9.25,
+            "is_audio_clip": True,
+        }
+        assert len(arrangement_song.tracks[1].arrangement_clips) == 2
+
+    def test_rejects_midi_only_track(
+        self,
+        arrangement_handler: ArrangementHandler,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "vocal.wav"
+        file_path.write_bytes(b"RIFF")
+
+        with pytest.raises(InvalidParamsError, match="does not accept audio clips"):
+            arrangement_handler.handle_import_audio(
+                {
+                    "track_index": 1,
+                    "file_path": str(file_path),
+                    "start_time": 8.0,
+                }
+            )
+
+    def test_rejects_missing_file(
+        self,
+        arrangement_handler: ArrangementHandler,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "missing.wav"
+
+        with pytest.raises(NotFoundError, match="File does not exist"):
+            arrangement_handler.handle_import_audio(
+                {
+                    "track_index": 2,
+                    "file_path": str(file_path),
+                    "start_time": 8.0,
+                }
+            )
+
+    def test_rejects_malformed_file_path(
+        self,
+        arrangement_handler: ArrangementHandler,
+    ) -> None:
+        with pytest.raises(
+            InvalidParamsError,
+            match="absolute local filesystem path",
+        ):
+            arrangement_handler.handle_import_audio(
+                {
+                    "track_index": 2,
+                    "file_path": "audio/vocal.wav",
+                    "start_time": 8.0,
+                }
             )
 
 

--- a/Tests/test_clip_handler.py
+++ b/Tests/test_clip_handler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from AbletonLiveMCP.dispatcher import InvalidParamsError, NotFoundError
 from AbletonLiveMCP.handlers.clip import ClipHandler
@@ -192,6 +194,12 @@ class _Slot:
         self._clip = _Clip(name="MIDI Clip", length=length, audio=False)
         self.has_clip = True
 
+    def create_audio_clip(self, file_path: str) -> None:
+        if self.has_clip:
+            raise RuntimeError("already has clip")
+        self._clip = _Clip(name=Path(file_path).stem, length=6.5, audio=True)
+        self.has_clip = True
+
     def delete_clip(self) -> None:
         self._clip = None
         self.has_clip = False
@@ -331,6 +339,105 @@ class TestCreateDelete:
         result = handler_clip.handle_delete({"track_index": 1, "clip_slot_index": 2})
         assert result == {"track_index": 1, "clip_slot_index": 2}
         assert not song_clip.tracks[0].clip_slots[1].has_clip
+
+
+class TestImportAudio:
+    def test_success_on_audio_track(self, tmp_path) -> None:
+        file_path = tmp_path / "drums.wav"
+        file_path.write_bytes(b"RIFF")
+        song = _FakeSong()
+        song.tracks = [_track_with_slots(_Slot(), _Slot(), midi=False, audio=True)]
+        handler = ClipHandler(_FakeControlSurface(song))
+
+        result = handler.handle_import_audio(
+            {
+                "track_index": 1,
+                "clip_slot_index": 1,
+                "file_path": str(file_path),
+            }
+        )
+
+        assert result == {
+            "track_index": 1,
+            "clip_slot_index": 1,
+            "name": "drums",
+            "file_path": str(file_path),
+            "length": 6.5,
+            "is_audio_clip": True,
+        }
+        slot = song.tracks[0].clip_slots[0]
+        assert slot.has_clip
+        assert slot.clip.is_audio_clip is True
+
+    def test_rejects_midi_only_track(self, tmp_path) -> None:
+        file_path = tmp_path / "drums.wav"
+        file_path.write_bytes(b"RIFF")
+        song = _FakeSong()
+        song.tracks = [_track_with_slots(_Slot(), _Slot(), midi=True, audio=False)]
+        handler = ClipHandler(_FakeControlSurface(song))
+
+        with pytest.raises(InvalidParamsError, match="does not accept audio clips"):
+            handler.handle_import_audio(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 1,
+                    "file_path": str(file_path),
+                }
+            )
+
+    def test_rejects_occupied_slot(self, tmp_path) -> None:
+        file_path = tmp_path / "drums.wav"
+        file_path.write_bytes(b"RIFF")
+        song = _FakeSong()
+        song.tracks = [
+            _track_with_slots(
+                _Slot(_Clip("Existing", audio=True)),
+                midi=False,
+                audio=True,
+            )
+        ]
+        handler = ClipHandler(_FakeControlSurface(song))
+
+        with pytest.raises(InvalidParamsError, match="already has a clip"):
+            handler.handle_import_audio(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 1,
+                    "file_path": str(file_path),
+                }
+            )
+
+    def test_rejects_missing_file(self, tmp_path) -> None:
+        file_path = tmp_path / "missing.wav"
+        song = _FakeSong()
+        song.tracks = [_track_with_slots(_Slot(), midi=False, audio=True)]
+        handler = ClipHandler(_FakeControlSurface(song))
+
+        with pytest.raises(NotFoundError, match="File does not exist"):
+            handler.handle_import_audio(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 1,
+                    "file_path": str(file_path),
+                }
+            )
+
+    def test_rejects_malformed_file_path(self) -> None:
+        song = _FakeSong()
+        song.tracks = [_track_with_slots(_Slot(), midi=False, audio=True)]
+        handler = ClipHandler(_FakeControlSurface(song))
+
+        with pytest.raises(
+            InvalidParamsError,
+            match="absolute local filesystem path",
+        ):
+            handler.handle_import_audio(
+                {
+                    "track_index": 1,
+                    "clip_slot_index": 1,
+                    "file_path": "samples/drums.wav",
+                }
+            )
 
 
 class TestDuplicate:

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -138,6 +138,17 @@ class _ArrangementHandler:
             ],
         }
 
+    def handle_import_audio(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_index": 2,
+            "name": "vocal",
+            "file_path": params["file_path"],
+            "start_time": params["start_time"],
+            "length": 8.5,
+            "is_audio_clip": True,
+        }
+
 
 class _SceneHandler:
     def handle_get_all(self, params):
@@ -170,6 +181,16 @@ class _SceneHandler:
 
 
 class _ClipHandler:
+    def handle_import_audio(self, params):
+        return {
+            "track_index": params["track_index"],
+            "clip_slot_index": params["clip_slot_index"],
+            "name": "drums",
+            "file_path": params["file_path"],
+            "length": 6.5,
+            "is_audio_clip": True,
+        }
+
     def handle_set_loop(self, params):
         return {
             "track_index": params["track_index"],
@@ -445,6 +466,36 @@ class TestFullRoundTrip:
 
         await conn.disconnect()
 
+    async def test_arrangement_audio_import_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(
+            command="arrangement.import_audio",
+            params={
+                "track_index": 2,
+                "file_path": "/tmp/vocal.wav",
+                "start_time": 12.0,
+            },
+            id="arrangement-import-1",
+        )
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "arrangement-import-1"
+        assert resp.result == {
+            "track_index": 2,
+            "clip_index": 2,
+            "name": "vocal",
+            "file_path": "/tmp/vocal.wav",
+            "start_time": 12.0,
+            "length": 8.5,
+            "is_audio_clip": True,
+        }
+
+        await conn.disconnect()
+
     async def test_clip_loop_payload_via_tcp(self, tcp_server) -> None:
         port, server, logs = tcp_server
         conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
@@ -471,6 +522,35 @@ class TestFullRoundTrip:
             "loop_start": 0.0,
             "loop_end": 4.0,
             "looping": True,
+        }
+
+        await conn.disconnect()
+
+    async def test_clip_audio_import_payload_via_tcp(self, tcp_server) -> None:
+        port, server, logs = tcp_server
+        conn = AbletonConnection(host="127.0.0.1", port=port, max_retries=1)
+        await conn.connect()
+
+        req = CommandRequest(
+            command="clip.import_audio",
+            params={
+                "track_index": 1,
+                "clip_slot_index": 3,
+                "file_path": "/tmp/drums.wav",
+            },
+            id="clip-import-1",
+        )
+        resp = await conn.send_command(req)
+
+        assert resp.status == "ok"
+        assert resp.id == "clip-import-1"
+        assert resp.result == {
+            "track_index": 1,
+            "clip_slot_index": 3,
+            "name": "drums",
+            "file_path": "/tmp/drums.wav",
+            "length": 6.5,
+            "is_audio_clip": True,
         }
 
         await conn.disconnect()

--- a/Tests/tools/test_arrangement.py
+++ b/Tests/tools/test_arrangement.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from mcp_ableton._app import mcp
 from mcp_ableton.protocol import CommandError, CommandResponse, ErrorDetail
 from mcp_ableton.tools.arrangement import (
+    ArrangementAudioImportResult,
     ArrangementClipCreatedResult,
     ArrangementClipInfo,
     ArrangementClipMovedResult,
@@ -22,6 +23,7 @@ from mcp_ableton.tools.arrangement import (
     create_arrangement_clip,
     get_arrangement_clips,
     get_arrangement_length,
+    import_audio_to_arrangement,
     move_arrangement_clip,
     set_arrangement_loop,
 )
@@ -32,6 +34,7 @@ TOOL_NAMES = [
     "move_arrangement_clip",
     "get_arrangement_length",
     "set_arrangement_loop",
+    "import_audio_to_arrangement",
 ]
 
 ARRANGEMENT_CLIPS_RESULT = {
@@ -58,6 +61,16 @@ ARRANGEMENT_CLIPS_RESULT = {
             "is_midi_clip": False,
         },
     ],
+}
+
+ARRANGEMENT_AUDIO_IMPORT_RESULT = {
+    "track_index": 2,
+    "clip_index": 2,
+    "name": "vocal",
+    "file_path": "/tmp/vocal.wav",
+    "start_time": 12.0,
+    "length": 8.5,
+    "is_audio_clip": True,
 }
 
 
@@ -121,6 +134,13 @@ class TestToolContracts:
         assert props["end_time"]["minimum"] == 0.0
         assert props["enabled"]["default"] is True
 
+    def test_import_audio_to_arrangement_schema(self) -> None:
+        tool = self._get_tool("import_audio_to_arrangement")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["start_time"]["minimum"] == 0.0
+        assert props["file_path"]["type"] == "string"
+
 
 class TestInputValidation:
     def _arg_model(self, tool_name: str):
@@ -164,6 +184,11 @@ class TestInputValidation:
         model = self._arg_model("set_arrangement_loop")
         with pytest.raises(ValidationError):
             model(start_time=0.0, end_time=-1.0)
+
+    def test_import_audio_to_arrangement_rejects_relative_file_path(self) -> None:
+        model = self._arg_model("import_audio_to_arrangement")
+        with pytest.raises(ValidationError):
+            model(track_index=2, file_path="audio/vocal.wav", start_time=4.0)
 
 
 class TestGetArrangementClips:
@@ -384,3 +409,62 @@ class TestArrangementLengthAndLoop:
             )
 
         mock_connection.send_command.assert_not_called()
+
+
+class TestImportAudioToArrangement:
+    async def test_sends_correct_command(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "vocal.wav"
+        file_path.write_bytes(b"RIFF")
+        response_result = dict(ARRANGEMENT_AUDIO_IMPORT_RESULT)
+        response_result["file_path"] = str(file_path)
+        mock_connection.send_command.return_value = _ok_response(response_result)
+
+        result = await import_audio_to_arrangement(
+            ctx=mock_context,
+            track_index=2,
+            file_path=str(file_path),
+            start_time=12.0,
+        )
+
+        assert isinstance(result, ArrangementAudioImportResult)
+        assert result.clip_index == 2
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "arrangement.import_audio"
+        assert req.params == {
+            "track_index": 2,
+            "file_path": str(file_path),
+            "start_time": 12.0,
+        }
+
+    async def test_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "missing.wav"
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message=f"File does not exist: {file_path}",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await import_audio_to_arrangement(
+                ctx=mock_context,
+                track_index=2,
+                file_path=str(file_path),
+                start_time=4.0,
+            )
+
+
+class TestResponseModels:
+    def test_arrangement_audio_import_accepts_valid(self) -> None:
+        result = ArrangementAudioImportResult.model_validate(
+            ARRANGEMENT_AUDIO_IMPORT_RESULT
+        )
+        assert result.is_audio_clip is True

--- a/Tests/tools/test_clip.py
+++ b/Tests/tools/test_clip.py
@@ -28,6 +28,7 @@ from mcp_ableton.tools.clip import (
     NotesAddedResult,
     NotesRemovedResult,
     NotesSetResult,
+    SessionAudioImportResult,
     add_notes_to_clip,
     create_clip,
     delete_clip,
@@ -36,6 +37,7 @@ from mcp_ableton.tools.clip import (
     get_clip_automation,
     get_clip_info,
     get_clip_notes,
+    import_audio_to_session,
     remove_notes,
     set_clip_automation,
     set_clip_color,
@@ -53,6 +55,7 @@ TOOL_NAMES = [
     "fire_clip",
     "stop_clip",
     "get_clip_info",
+    "import_audio_to_session",
     "set_clip_loop",
     "set_clip_color",
     "get_clip_notes",
@@ -130,6 +133,15 @@ CLIP_COLOR_RESULT = {
     "color_index": 17,
 }
 
+SESSION_AUDIO_IMPORT_RESULT = {
+    "track_index": 2,
+    "clip_slot_index": 3,
+    "name": "beat",
+    "file_path": "/tmp/beat.wav",
+    "length": 7.5,
+    "is_audio_clip": True,
+}
+
 CLIP_AUTOMATION_RESULT = {
     "track_index": 1,
     "clip_slot_index": 2,
@@ -191,6 +203,13 @@ class TestToolContracts:
         props = tool.parameters["properties"]
         assert props["color_index"]["minimum"] == 0
 
+    def test_import_audio_to_session_schema(self) -> None:
+        tool = self._get_tool("import_audio_to_session")
+        props = tool.parameters["properties"]
+        assert props["track_index"]["minimum"] == 1
+        assert props["clip_slot_index"]["minimum"] == 1
+        assert props["file_path"]["type"] == "string"
+
     def test_set_clip_automation_schema(self) -> None:
         tool = self._get_tool("set_clip_automation")
         props = tool.parameters["properties"]
@@ -237,6 +256,11 @@ class TestInputValidation:
         model = self._arg_model("set_clip_color")
         with pytest.raises(ValidationError):
             model(track_index=1, clip_slot_index=1, color_index=-1)
+
+    def test_import_audio_to_session_rejects_relative_file_path(self) -> None:
+        model = self._arg_model("import_audio_to_session")
+        with pytest.raises(ValidationError):
+            model(track_index=1, clip_slot_index=1, file_path="samples/beat.wav")
 
     def test_set_clip_automation_rejects_empty_point_list(self) -> None:
         model = self._arg_model("set_clip_automation")
@@ -849,6 +873,57 @@ class TestDeleteDuplicateFireStop:
         assert mock_connection.send_command.call_args[0][0].command == "clip.stop"
 
 
+class TestImportAudioToSession:
+    async def test_import_audio_to_session(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "beat.wav"
+        file_path.write_bytes(b"RIFF")
+        response_result = dict(SESSION_AUDIO_IMPORT_RESULT)
+        response_result["file_path"] = str(file_path)
+        mock_connection.send_command.return_value = _ok_response(response_result)
+
+        result = await import_audio_to_session(
+            ctx=mock_context,
+            track_index=2,
+            clip_slot_index=3,
+            file_path=str(file_path),
+        )
+
+        assert isinstance(result, SessionAudioImportResult)
+        assert result.clip_slot_index == 3
+        req = mock_connection.send_command.call_args[0][0]
+        assert req.command == "clip.import_audio"
+        assert req.params == {
+            "track_index": 2,
+            "clip_slot_index": 3,
+            "file_path": str(file_path),
+        }
+
+    async def test_import_audio_to_session_raises_on_error(
+        self,
+        mock_context: MagicMock,
+        mock_connection: AsyncMock,
+        tmp_path,
+    ) -> None:
+        file_path = tmp_path / "missing.wav"
+        mock_connection.send_command.return_value = _error_response(
+            code="NOT_FOUND",
+            message=f"File does not exist: {file_path}",
+        )
+
+        with pytest.raises(CommandError, match="NOT_FOUND"):
+            await import_audio_to_session(
+                ctx=mock_context,
+                track_index=1,
+                clip_slot_index=1,
+                file_path=str(file_path),
+            )
+
+
 class TestResponseModels:
     def test_clip_automation_accepts_valid(self) -> None:
         automation = ClipAutomationResult.model_validate(CLIP_AUTOMATION_RESULT)
@@ -867,3 +942,7 @@ class TestResponseModels:
     def test_clip_info_accepts_valid(self) -> None:
         c = ClipInfo.model_validate(CLIP_INFO_RESULT)
         assert c.name == "Kick"
+
+    def test_session_audio_import_result_accepts_valid(self) -> None:
+        result = SessionAudioImportResult.model_validate(SESSION_AUDIO_IMPORT_RESULT)
+        assert result.is_audio_clip is True

--- a/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
+++ b/docs/decisions/002-competitor-analysis-and-tool-roadmap.md
@@ -371,7 +371,8 @@ These tools match or exceed the original ahujasid feature set, add arrangement v
 
 ### Phase 2: Extended Capabilities
 
-These tools add scene management, arrangement view (our key differentiator), sends/returns, recording, and clip properties.
+These tools add scene management, arrangement view (our key differentiator),
+audio import, sends/returns, recording, and clip properties.
 
 #### Scene Management (7 tools)
 - `get_scenes` — list all scenes with names and indices
@@ -388,6 +389,10 @@ These tools add scene management, arrangement view (our key differentiator), sen
 - `move_arrangement_clip` — move clip to new position/track
 - `get_arrangement_length` — total arrangement length
 - `set_arrangement_loop` — loop start, end, enabled
+
+#### Audio Import (2 tools)
+- `import_audio_to_session` — import a local audio file into an empty session slot
+- `import_audio_to_arrangement` — import a local audio file into arrangement at a beat position
 
 #### Sends & Returns (4 tools)
 - `get_return_tracks` — list return tracks
@@ -411,7 +416,7 @@ These tools add scene management, arrangement view (our key differentiator), sen
 - `undo` — undo last action
 - `redo` — redo last undone action
 
-**Phase 2 total: 26 tools** (cumulative: 63 tools)
+**Phase 2 total: 28 tools** (cumulative: 65 tools)
 
 ### Phase 3: Advanced
 
@@ -441,7 +446,7 @@ These tools cover niche but valuable capabilities. Prioritized based on communit
 - `get_groove_pool` — list available grooves
 - `apply_groove` — apply groove to clip
 
-**Phase 3 total: 14 tools** (cumulative: 75 tools)
+**Phase 3 total: 14 tools** (cumulative: 79 tools)
 
 ### Explicitly excluded
 
@@ -517,6 +522,7 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `stop_scene` | `scene.stop` |
 | `set_scene_name` | `scene.set_name` |
 | `create_clip` | `clip.create` |
+| `import_audio_to_session` | `clip.import_audio` |
 | `delete_clip` | `clip.delete` |
 | `duplicate_clip` | `clip.duplicate` |
 | `set_clip_name` | `clip.set_name` |
@@ -533,6 +539,7 @@ Commands use `category.action` dot notation (adopted from ptaczek):
 | `set_clip_automation` | `clip.set_automation` |
 | `get_arrangement_clips` | `arrangement.get_clips` |
 | `create_arrangement_clip` | `arrangement.create_clip` |
+| `import_audio_to_arrangement` | `arrangement.import_audio` |
 | `move_arrangement_clip` | `arrangement.move_clip` |
 | `get_arrangement_length` | `arrangement.get_length` |
 | `set_arrangement_loop` | `arrangement.set_loop` |

--- a/remote_script/AbletonLiveMCP/handlers/arrangement.py
+++ b/remote_script/AbletonLiveMCP/handlers/arrangement.py
@@ -265,6 +265,47 @@ class ArrangementHandler(BaseHandler):
 
         return self._run_on_main_thread(_create)
 
+    def handle_import_audio(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Import an audio file into arrangement view on an audio track."""
+        track_index = self._require_track_index(params, "track_index")
+        assert track_index is not None
+        file_path = self._require_absolute_file_path(params, "file_path")
+        self._require_existing_file(file_path)
+        start_time = self._require_number(params, "start_time", minimum=0.0)
+
+        def _import() -> dict[str, Any]:
+            track, resolved_track_index, _ = self._resolve_track(track_index)
+            if not bool(track.has_audio_input):
+                raise InvalidParamsError(
+                    f"Track {resolved_track_index} does not accept audio clips"
+                )
+
+            before = list(track.arrangement_clips)
+            try:
+                track.create_audio_clip(file_path, start_time)
+            except Exception as exc:
+                raise InvalidParamsError(
+                    "Unable to import audio clip to arrangement track "
+                    f"{resolved_track_index}: {exc}"
+                ) from exc
+
+            clip_index, clip = self._find_new_clip(
+                before,
+                list(track.arrangement_clips),
+                action="import_audio_to_arrangement",
+            )
+            return {
+                "track_index": resolved_track_index,
+                "clip_index": clip_index,
+                "name": str(clip.name),
+                "file_path": file_path,
+                "start_time": float(clip.start_time),
+                "length": float(clip.length),
+                "is_audio_clip": bool(clip.is_audio_clip),
+            }
+
+        return self._run_on_main_thread(_import)
+
     def handle_move_clip(self, params: dict[str, Any]) -> dict[str, Any]:
         """Move an arrangement clip to a new track/time by duplicate-then-delete."""
         source_track_index = self._require_track_index(params, "track_index")

--- a/remote_script/AbletonLiveMCP/handlers/base.py
+++ b/remote_script/AbletonLiveMCP/handlers/base.py
@@ -5,9 +5,12 @@ The handler runs on a client-socket thread; use ``_run_on_main_thread``
 for any operation that mutates Ableton's state.
 """
 
+import os
 import queue
 from collections.abc import Callable
 from typing import Any
+
+from ..dispatcher import InvalidParamsError, NotFoundError
 
 MAIN_THREAD_TIMEOUT = 30
 
@@ -28,6 +31,28 @@ class BaseHandler:
 
     def _log(self, message: str) -> None:
         self._control_surface.log_message(message)
+
+    def _require_absolute_file_path(
+        self,
+        params: dict[str, Any],
+        name: str = "file_path",
+    ) -> str:
+        """Validate and return an absolute local filesystem path parameter."""
+        raw_value = params.get(name)
+        if raw_value is None:
+            raise InvalidParamsError(f"'{name}' parameter is required")
+        if not isinstance(raw_value, str) or not raw_value:
+            raise InvalidParamsError(f"'{name}' must be a string")
+        if "://" in raw_value or not os.path.isabs(raw_value):
+            raise InvalidParamsError(
+                f"'{name}' must be an absolute local filesystem path"
+            )
+        return raw_value
+
+    def _require_existing_file(self, file_path: str) -> None:
+        """Ensure the referenced local file exists before touching Live."""
+        if not os.path.isfile(file_path):
+            raise NotFoundError(f"File does not exist: {file_path}")
 
     def _run_on_main_thread(self, fn: Callable[[], Any]) -> Any:
         """Schedule *fn* on Ableton's main thread and block until it completes.

--- a/remote_script/AbletonLiveMCP/handlers/clip.py
+++ b/remote_script/AbletonLiveMCP/handlers/clip.py
@@ -748,6 +748,49 @@ class ClipHandler(BaseHandler):
 
         return self._run_on_main_thread(_do)
 
+    def handle_import_audio(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Import an audio file into an empty session slot on an audio track."""
+        file_path = self._require_absolute_file_path(params, "file_path")
+        self._require_existing_file(file_path)
+
+        def _do() -> dict[str, Any]:
+            track, slot, track_index, slot_index, _lo = self._resolve_clip_slot(
+                params,
+            )
+            if slot.has_clip:
+                raise InvalidParamsError(
+                    f"Clip slot {slot_index} on track {track_index} already has a clip"
+                )
+            if not bool(track.has_audio_input):
+                raise InvalidParamsError(
+                    f"Track {track_index} does not accept audio clips"
+                )
+
+            try:
+                slot.create_audio_clip(file_path)
+            except Exception as exc:
+                raise InvalidParamsError(
+                    "Failed to import audio into session clip slot "
+                    f"{slot_index} on track {track_index}: {exc}"
+                ) from exc
+
+            if not slot.has_clip:
+                raise RuntimeError(
+                    "Audio import completed but no clip appeared in the target slot"
+                )
+
+            clip = slot.clip
+            return {
+                "track_index": track_index,
+                "clip_slot_index": slot_index,
+                "name": str(clip.name),
+                "file_path": file_path,
+                "length": float(clip.length),
+                "is_audio_clip": bool(clip.is_audio_clip),
+            }
+
+        return self._run_on_main_thread(_do)
+
     def handle_delete(self, params: dict[str, Any]) -> dict[str, Any]:
         """Remove the clip in the given slot."""
 

--- a/src/mcp_ableton/tools/arrangement.py
+++ b/src/mcp_ableton/tools/arrangement.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Annotated
 
 from mcp.server.fastmcp import Context  # noqa: TCH002
-from pydantic import BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field
 
 from mcp_ableton._app import mcp
 from mcp_ableton.protocol import CommandRequest
@@ -43,6 +44,26 @@ PositiveLength = Annotated[
         description="Clip length in beats (must be > 0).",
         gt=0.0,
     ),
+]
+
+
+def _validate_absolute_local_file_path(value: str) -> str:
+    """Require an absolute local filesystem path without URI schemes."""
+    if "://" in value:
+        raise ValueError("'file_path' must be an absolute local filesystem path")
+
+    is_absolute = (
+        PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+    )
+    if not is_absolute:
+        raise ValueError("'file_path' must be an absolute local filesystem path")
+    return value
+
+
+AudioFilePath = Annotated[
+    str,
+    AfterValidator(_validate_absolute_local_file_path),
+    Field(description="Absolute local filesystem path to an audio file."),
 ]
 
 
@@ -98,6 +119,18 @@ class ArrangementLoopResult(BaseModel):
     start_time: float
     end_time: float
     enabled: bool
+
+
+class ArrangementAudioImportResult(BaseModel):
+    """Result of ``import_audio_to_arrangement``."""
+
+    track_index: int
+    clip_index: int
+    name: str
+    file_path: str
+    start_time: float
+    length: float
+    is_audio_clip: bool
 
 
 def _get_connection(ctx: Context) -> AbletonConnection:
@@ -228,16 +261,41 @@ async def set_arrangement_loop(
     return ArrangementLoopResult.model_validate(response.result)
 
 
+@mcp.tool()
+async def import_audio_to_arrangement(
+    ctx: Context,
+    track_index: TrackIndex,
+    file_path: AudioFilePath,
+    start_time: StartTime,
+) -> ArrangementAudioImportResult:
+    """Import an audio file into arrangement view on an audio track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="arrangement.import_audio",
+        params={
+            "track_index": track_index,
+            "file_path": file_path,
+            "start_time": start_time,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return ArrangementAudioImportResult.model_validate(response.result)
+
+
 __all__ = [
+    "ArrangementAudioImportResult",
     "ArrangementClipCreatedResult",
     "ArrangementClipInfo",
     "ArrangementClipMovedResult",
     "ArrangementClipsResult",
     "ArrangementLengthResult",
     "ArrangementLoopResult",
+    "AudioFilePath",
     "create_arrangement_clip",
     "get_arrangement_clips",
     "get_arrangement_length",
+    "import_audio_to_arrangement",
     "move_arrangement_clip",
     "set_arrangement_loop",
 ]

--- a/src/mcp_ableton/tools/clip.py
+++ b/src/mcp_ableton/tools/clip.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Annotated, Any
 
 from mcp.server.fastmcp import Context  # noqa: TCH002
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
 from mcp_ableton._app import mcp
 from mcp_ableton.protocol import CommandRequest
@@ -22,6 +23,19 @@ NoteDuration = Annotated[float, Field(gt=0.0)]
 NoteVelocity = Annotated[float, Field(ge=0.0, le=127.0)]
 NoteProbability = Annotated[float, Field(ge=0.0, le=1.0)]
 NoteVelocityDeviation = Annotated[float, Field(ge=-127.0, le=127.0)]
+
+
+def _validate_absolute_local_file_path(value: str) -> str:
+    """Require an absolute local filesystem path without URI schemes."""
+    if "://" in value:
+        raise ValueError("'file_path' must be an absolute local filesystem path")
+
+    is_absolute = (
+        PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+    )
+    if not is_absolute:
+        raise ValueError("'file_path' must be an absolute local filesystem path")
+    return value
 
 
 class ClipCreatedResult(BaseModel):
@@ -84,6 +98,24 @@ class ClipColorResult(BaseModel):
     track_index: int
     clip_slot_index: int
     color_index: int
+
+
+AbsoluteLocalFilePath = Annotated[
+    str,
+    AfterValidator(_validate_absolute_local_file_path),
+    Field(description="Absolute local filesystem path to an audio file."),
+]
+
+
+class SessionAudioImportResult(BaseModel):
+    """Result of ``import_audio_to_session``."""
+
+    track_index: int
+    clip_slot_index: int
+    name: str
+    file_path: str
+    length: float
+    is_audio_clip: bool
 
 
 class NoteObjectInput(BaseModel):
@@ -466,6 +498,28 @@ async def set_clip_color(
 
 
 @mcp.tool()
+async def import_audio_to_session(
+    ctx: Context,
+    track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
+    clip_slot_index: ClipSlotIndex,
+    file_path: AbsoluteLocalFilePath,
+) -> SessionAudioImportResult:
+    """Import an audio file into an empty session slot on an audio track."""
+    connection = _get_connection(ctx)
+    request = CommandRequest(
+        command="clip.import_audio",
+        params={
+            "track_index": track_index,
+            "clip_slot_index": clip_slot_index,
+            "file_path": file_path,
+        },
+    )
+    response = await connection.send_command(request)
+    response.raise_on_error()
+    return SessionAudioImportResult.model_validate(response.result)
+
+
+@mcp.tool()
 async def get_clip_notes(
     ctx: Context,
     track_index: Annotated[int, Field(description="1-based track index.", ge=1)],
@@ -680,6 +734,7 @@ async def set_clip_notes(
 
 
 __all__ = [
+    "AbsoluteLocalFilePath",
     "ClipAutomationPoint",
     "ClipAutomationResult",
     "ClipAutomationSetResult",
@@ -698,6 +753,7 @@ __all__ = [
     "NotesAddedResult",
     "NotesRemovedResult",
     "NotesSetResult",
+    "SessionAudioImportResult",
     "add_notes_to_clip",
     "create_clip",
     "delete_clip",
@@ -706,6 +762,7 @@ __all__ = [
     "get_clip_automation",
     "get_clip_info",
     "get_clip_notes",
+    "import_audio_to_session",
     "remove_notes",
     "set_clip_automation",
     "set_clip_color",


### PR DESCRIPTION
## Summary

- add `import_audio_to_session` and `import_audio_to_arrangement` on the existing clip and arrangement surfaces
- validate absolute local file paths at the MCP boundary and keep Live-side path, track, slot, and file checks in the existing handlers
- keep audio clip property editing out of scope for `#29`

## MCP tools

- `import_audio_to_session(track_index, clip_slot_index, file_path)` on `src/mcp_ableton/tools/clip.py`
- `import_audio_to_arrangement(track_index, file_path, start_time)` on `src/mcp_ableton/tools/arrangement.py`
- add typed result models for both import flows and export them through each module’s public API

## Remote Script

- extend `ClipHandler` with `clip.import_audio` using `clip_slot.create_audio_clip(path)`
- extend `ArrangementHandler` with `arrangement.import_audio` using `track.create_audio_clip(file_path, start_time)` plus the existing before/after clip diff pattern
- add shared absolute-path and file-existence helpers in `BaseHandler`
- return `INVALID_PARAMS` for malformed paths, incompatible tracks, occupied session slots, and Live import failures; return `NOT_FOUND` for missing tracks/slots/files

## Tests

- extend `Tests/tools/test_clip.py` and `Tests/tools/test_arrangement.py`
- extend `Tests/test_clip_handler.py`, `Tests/test_arrangement_handler.py`, and `Tests/test_integration.py`
- validation run:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/`
  - `uv run pytest`

## Manual verification

- Live target: Ableton Live 12.2.5
- MCP path: real stdio server via `uv run --directory /Users/markfeaver/Projects/AbletonLiveMCP mcp-ableton`
- local audio file: `/Users/markfeaver/Music/StemRoller/Liars Remorse/drums.wav`
- runtime API confirmation: `clip_slot.create_audio_clip(path)` and `track.create_audio_clip(file_path, start_time)` both succeeded on Live 12.2.5
- exact tools called:
  - `get_session_info`
  - `create_audio_track`
  - `import_audio_to_session`
  - `get_clip_info`
  - `import_audio_to_arrangement`
  - `get_arrangement_clips`
  - `import_audio_to_session` again for occupied-slot failure
  - `import_audio_to_arrangement` again for missing-file failure
  - `delete_track` for cleanup
- session import success: clip `drums` imported to track 5, slot 1
- arrangement import success: clip `drums` imported to track 5 at beat `32.0`
- `INVALID_PARAMS` example: `import_audio_to_session` on the occupied slot returned `[INVALID_PARAMS] Clip slot 1 on track 5 already has a clip`
- `NOT_FOUND` example: `import_audio_to_arrangement` with `/Users/markfeaver/Music/StemRoller/Liars Remorse/does-not-exist.wav` returned `[NOT_FOUND] File does not exist: /Users/markfeaver/Music/StemRoller/Liars Remorse/does-not-exist.wav`
- verification reads:
  - `get_clip_info` reported `drums` as an audio clip in session slot 1
  - `get_arrangement_clips` reported `drums` on track 5 starting at `32.0`
- cleanup: deleted the temporary verification track after the smoke run
- `~/Library/Preferences/Ableton/Live 12.2.5/Log.txt` stayed free of traceback/exception markers for the smoke run

## Docs

- update `docs/decisions/002-competitor-analysis-and-tool-roadmap.md` phase tables and command mapping for the two new import tools
- refresh `README.md` current-status text to include session and arrangement audio import

Closes #15
